### PR TITLE
add Swiftlint and Danger

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,20 @@
+identifier_name:
+    min_length:
+        warning: 1
+        error: 0
+
+large_tuple:
+    warning: 5
+    error: 6
+
+opt_in_rules:
+  - closure_spacing
+
+disabled_rules: # rule identifiers to exclude from running
+  - function_body_length
+  - line_length
+  - trailing_comma
+  - force_try
+  - colon
+
+reporter: "json"

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,12 +54,15 @@ cache:
 before_install:
   - brew update
   - brew outdated carthage || brew upgrade carthage
+  - brew outdated swiftlint || brew upgrade swiftlint
+  - gem install danger
   - carthage bootstrap --project-directory "$AZURECORE" --verbose --no-use-binaries --cache-builds
 
 script:
   - set -o pipefail
   - xcodebuild -version
   - xcodebuild -showsdks
+  - swiftlint lint --quiet >> lintreport.json || true # Dont crash on lint errors
 
   # Build Framework in Debug and Run Tests if specified
   - if [ $RUN_TESTS == "YES" ]; then
@@ -79,3 +82,6 @@ script:
   - if [ $POD_LINT == "YES" ]; then
       pod lib lint;
     fi
+
+after_success:
+  - danger

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,47 @@
+# Ensure a clean commits history
+if git.commits.any? { |c| c.message =~ /^Merge branch '#{github.branch_for_base}'/ }
+  fail('Please rebase to get rid of the merge commits in this PR')
+end
+can_merge = github.pr_json["mergeable"]
+is_merged = github.pr_json["merged"]
+
+if is_merged
+  warn("This PR was merged before CI was done.", sticky: false)
+else
+  warn("This PR cannot be merged yet.", sticky: false) unless can_merge
+end
+
+# Make it more obvious that a PR is a work in progress and shouldn't be merged yet
+warn("PR is classed as Work in Progress") if github.pr_title.include? "[WIP]"
+
+# Warn when there is a big PR
+warn("Big PR") if git.lines_of_code > 1000
+
+#ENSURE THERE IS A SUMMARY FOR A PR
+warn("Please provide a summary in the Pull Request description.") if github.pr_body.length < 5
+
+# LINT Comments in for each Line
+jsonpath = "lintreport.json"
+contents = File.read jsonpath
+require "json"
+if contents.to_s == ''
+	contents = "[]"
+end
+json = JSON.parse contents
+json.each do |object|
+   shortFile =  object["file"]
+   shortFile.sub! "/Users/travis/build/Azure/Azure.iOS/", ''
+   shortFile = shortFile.to_s || ''
+   msg = object["reason"].to_s || ''
+   severity = object["severity"].to_s || ''
+   isError = severity == "Error"
+   line = object["line"] || 1
+   #only warn for files that were edited in this PR.
+   if isError
+    warn(msg, file: "/" + shortFile, line: line) if isError
+   elsif git.modified_files.include? shortFile
+   	warn(msg, file: "/" + shortFile, line: line) unless isError
+   else
+   	message(msg, file: shortFile, line: line)
+   end
+end


### PR DESCRIPTION
Changes Proposed in this pull request:
- added [swiftlint](https://github.com/realm/SwiftLint) 
- added swiftlint [config](https://github.com/realm/SwiftLint/blob/master/Rules.md)
- added [Danger](http://danger.systems/ruby/) 

Missing:
- finalize Danger [bot setup](http://danger.systems/guides/getting_started.html#creating-a-bot-account-for-danger-to-use)
- add `DANGER_GITHUB_API_TOKEN` to travis ci

Notes:

Currently these seem to run in every build in the matrix. If it is desired tp only run once then we can:
1) Adapt [travis CI stages](https://docs.travis-ci.com/user/build-stages#Build-Stages-and-Build-Matrix-Expansion)
2) Run Swiftlint and Danger as part of one of the builds only. 

```
before_install:
    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then gem install danger ; fi
    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated swiftlint || brew upgrade swiftlint ; fi

after_success:
    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then danger  ; fi
```
