### PR TITLE
Add metadata to the Response object

### DIFF
--- a/AzureCore/Source/DateFormat.swift
+++ b/AzureCore/Source/DateFormat.swift
@@ -12,7 +12,8 @@ public struct DateFormat {
     
     public static let httpDateFormat    = "E, dd MMM yyyy HH:mm:ss zzz"         // https://tools.ietf.org/html/rfc7231#section-7.1.1.1
     public static let iso8601Format     = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX"   // http://www.iso.org/iso/catalogue_detail?csnumber=40874
-    
+    public static let rfc1123Format     = "EEE, dd MMM yyyy HH:mm:ss z"
+
     public static let calendar  = Calendar(identifier: .iso8601)
     
     public static let locale    = Locale(identifier: "en_US_POSIX")
@@ -46,6 +47,18 @@ public struct DateFormat {
         formatter.timeZone      = timeZone
         formatter.dateFormat    = iso8601Format
         
+        return formatter
+    }
+
+    public static func getRFC1123Formatter() -> DateFormatter {
+
+        let formatter = DateFormatter()
+
+        formatter.calendar = calendar
+        formatter.locale = locale
+        formatter.timeZone = timeZone
+        formatter.dateFormat = rfc1123Format
+
         return formatter
     }
 }

--- a/AzureData/AzureData.xcodeproj/project.pbxproj
+++ b/AzureData/AzureData.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		32532A5A207825A1002BFFCA /* ResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32532A59207825A1002BFFCA /* ResponseMetadata.swift */; };
+		32532A5C207825A1002BFFCA /* ResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32532A59207825A1002BFFCA /* ResponseMetadata.swift */; };
+		32532A5E207825A1002BFFCA /* ResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32532A59207825A1002BFFCA /* ResponseMetadata.swift */; };
+		32532A60207825A1002BFFCA /* ResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32532A59207825A1002BFFCA /* ResponseMetadata.swift */; };
+		32AD4619207976AB00A0D02F /* ResponseMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */; };
+		32AD461A207976AB00A0D02F /* ResponseMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */; };
+		32AD461B207976AB00A0D02F /* ResponseMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */; };
 		9302CE412059A3A5000F6885 /* AzureCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9302CE422059A3A5000F6885 /* AzureCore.framework */; };
 		9302CE432059A3C5000F6885 /* AzureCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9302CE442059A3C5000F6885 /* AzureCore.framework */; };
 		9302CE452059A3D2000F6885 /* AzureCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9302CE462059A3D2000F6885 /* AzureCore.framework */; };
@@ -265,6 +272,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		32532A59207825A1002BFFCA /* ResponseMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseMetadata.swift; sourceTree = "<group>"; };
+		32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseMetadataTests.swift; sourceTree = "<group>"; };
 		9302CE422059A3A5000F6885 /* AzureCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AzureCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9302CE442059A3C5000F6885 /* AzureCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AzureCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9302CE462059A3D2000F6885 /* AzureCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AzureCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -497,6 +506,7 @@
 			isa = PBXGroup;
 			children = (
 				B522403D1FB33D1200D0343F /* QueryTests.swift */,
+				32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */,
 			);
 			name = Domain;
 			sourceTree = "<group>";
@@ -516,6 +526,7 @@
 				B58361BD1FBA13A0001CEC66 /* Document.swift */,
 				B58361C21FBA13B0001CEC66 /* DocumentCollection.swift */,
 				B58361D11FBA15A8001CEC66 /* Offer.swift */,
+				32532A59207825A1002BFFCA /* ResponseMetadata.swift */,
 				B58361D61FBA16F9001CEC66 /* Permission.swift */,
 				93935D9A20585C8600F1832A /* PermissionMode.swift */,
 				B58361DB1FBA17B5001CEC66 /* StoredProcedure.swift */,
@@ -867,6 +878,7 @@
 				B58361C41FBA13B0001CEC66 /* DocumentCollection.swift in Sources */,
 				B5B6AC251FBA4B3900B93106 /* Query.swift in Sources */,
 				93935D9C20585C8600F1832A /* PermissionMode.swift in Sources */,
+				32532A5C207825A1002BFFCA /* ResponseMetadata.swift in Sources */,
 				9317A81820656ED100338B63 /* ResourceOracle.swift in Sources */,
 				931EA5C41FBE6920003CCFF4 /* DocumentClientExtensions.swift in Sources */,
 				B58361B41FB78F7A001CEC66 /* Response.swift in Sources */,
@@ -903,6 +915,7 @@
 				931EA5C21FBE2775003CCFF4 /* CodableResourceTests.swift in Sources */,
 				B522406B1FB33DF800D0343F /* DocumentTests.swift in Sources */,
 				B52240741FB33DF800D0343F /* CollectionStoredProcedureExtensionsTests.swift in Sources */,
+				32AD461A207976AB00A0D02F /* ResponseMetadataTests.swift in Sources */,
 				B52240721FB33DF800D0343F /* CollectionTriggerExtensionsTests.swift in Sources */,
 				B52240731FB33DF800D0343F /* UserTests.swift in Sources */,
 				B52240761FB33DF800D0343F /* CollectionDocumentExtensionsTests.swift in Sources */,
@@ -941,6 +954,7 @@
 				B58361C51FBA13B0001CEC66 /* DocumentCollection.swift in Sources */,
 				B5B6AC261FBA4B3900B93106 /* Query.swift in Sources */,
 				93935D9D20585C8600F1832A /* PermissionMode.swift in Sources */,
+				32532A5E207825A1002BFFCA /* ResponseMetadata.swift in Sources */,
 				9317A81920656ED100338B63 /* ResourceOracle.swift in Sources */,
 				931EA5C61FBE6922003CCFF4 /* DocumentClientExtensions.swift in Sources */,
 				B58361AF1FB78F7A001CEC66 /* Response.swift in Sources */,
@@ -977,6 +991,7 @@
 				931EA5C31FBE2775003CCFF4 /* CodableResourceTests.swift in Sources */,
 				B522407F1FB33DFA00D0343F /* DocumentTests.swift in Sources */,
 				B52240881FB33DFA00D0343F /* CollectionStoredProcedureExtensionsTests.swift in Sources */,
+				32AD461B207976AB00A0D02F /* ResponseMetadataTests.swift in Sources */,
 				B52240861FB33DFA00D0343F /* CollectionTriggerExtensionsTests.swift in Sources */,
 				B52240871FB33DFA00D0343F /* UserTests.swift in Sources */,
 				B522408A1FB33DFA00D0343F /* CollectionDocumentExtensionsTests.swift in Sources */,
@@ -1015,6 +1030,7 @@
 				B58361C61FBA13B0001CEC66 /* DocumentCollection.swift in Sources */,
 				B5B6AC271FBA4B3900B93106 /* Query.swift in Sources */,
 				93935D9E20585C8600F1832A /* PermissionMode.swift in Sources */,
+				32532A60207825A1002BFFCA /* ResponseMetadata.swift in Sources */,
 				9317A81A20656ED100338B63 /* ResourceOracle.swift in Sources */,
 				931EA5C51FBE6922003CCFF4 /* DocumentClientExtensions.swift in Sources */,
 				B58361AA1FB78F78001CEC66 /* Response.swift in Sources */,
@@ -1058,6 +1074,7 @@
 				B583619A1FB779B6001CEC66 /* Response.swift in Sources */,
 				B5B6AC241FBA4B3900B93106 /* Query.swift in Sources */,
 				93935D9B20585C8600F1832A /* PermissionMode.swift in Sources */,
+				32532A5A207825A1002BFFCA /* ResponseMetadata.swift in Sources */,
 				9317A81720656ED100338B63 /* ResourceOracle.swift in Sources */,
 				931EA5BF1FBE201F003CCFF4 /* DocumentClientExtensions.swift in Sources */,
 				B583619D1FB77A70001CEC66 /* Resources.swift in Sources */,
@@ -1094,6 +1111,7 @@
 				931EA5C11FBE2775003CCFF4 /* CodableResourceTests.swift in Sources */,
 				B52240571FB33DF100D0343F /* DocumentTests.swift in Sources */,
 				B52240601FB33DF100D0343F /* CollectionStoredProcedureExtensionsTests.swift in Sources */,
+				32AD4619207976AB00A0D02F /* ResponseMetadataTests.swift in Sources */,
 				B522405E1FB33DF100D0343F /* CollectionTriggerExtensionsTests.swift in Sources */,
 				B522405F1FB33DF100D0343F /* UserTests.swift in Sources */,
 				B52240621FB33DF100D0343F /* CollectionDocumentExtensionsTests.swift in Sources */,

--- a/AzureData/Source/Resources/ResponseMetadata.swift
+++ b/AzureData/Source/Resources/ResponseMetadata.swift
@@ -1,0 +1,187 @@
+//
+//  ResponseMetadata.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+import AzureCore
+
+/// https://docs.microsoft.com/en-us/rest/api/cosmos-db/common-cosmosdb-rest-response-headers
+public struct ResponseMetadata {
+    /// The unique identifier of the operation.
+    public let activityId: String?
+
+    /// The alternate path to the resource constructed using
+    /// user-supplied IDs.
+    public let alternateContentPath: String?
+
+    /// The Content-Type is always `application/json`.
+    public let contentType: String?
+
+    /// Represents the intermediate state of query or read-feed
+    /// execution and is returned when there are additional
+    /// results aside from what was returned in the response.
+    /// Clients can resubmit the request with the request
+    /// header `x-ms-continuation` containing this value.
+    public let continuation: String?
+
+    /// The date time of the response operation.
+    public let date: Date?
+
+    /// The `etag` of the resource retrieved.
+    public let etag: String?
+
+    /// The number of items returned for a query or a read-feed request.
+    public let itemCount: Int?
+
+    /// The number of request units for the operation.
+    public let requestCharge: Double?
+
+    /// The allotted quota for a resource in a Azure CosmosDB account.
+    public let resourceQuota: Metrics?
+
+    /// The current usage of a resource in a Azure CosmosDB account.
+    public let resourceUsage: Metrics?
+
+    /// The number of seconds to wait to retry
+    /// the operation after an initial operation
+    /// received the HTTP status code 429
+    /// and was throttled.
+    public let retryAfter: TimeInterval?
+
+    /// The resource schema version.
+    public let schemaVersion: String?
+
+    /// The service version number.
+    public let serviceVersion: String?
+
+    /// The session token of the request.
+    public let sessionToken: String?
+
+    internal init(for response: HTTPURLResponse) {
+        let headers = response.allHeaderFields
+
+        self.activityId = headers[.msActivityId]
+        self.alternateContentPath = headers[.msAltContentPath]
+        self.contentType = headers["Content-Type"] as? String
+        self.continuation = headers[.msContinuation]
+        self.date = DateFormat.getRFC1123Formatter().date(from: (headers["Date"] as? String) ?? "")
+        self.etag = headers["Etag"] as? String
+        self.itemCount = headers[.msItemCount]
+        self.requestCharge = headers[.msRequestCharge]
+        self.resourceQuota = Metrics(headers[.msResourceQuota] ?? "")
+        self.resourceUsage = Metrics(headers[.msResourceUsage] ?? "")
+        self.retryAfter = (headers[.msRetryAfterMs] ?? 0) / 1000
+        self.schemaVersion = headers[.msSchemaversion]?.valueIfKeyValuePairElseSelf
+        self.serviceVersion = headers[.msServiceversion]?.valueIfKeyValuePairElseSelf
+        self.sessionToken = headers[.msSessionToken]
+    }
+
+    //  MARK: - Metrics
+
+    public struct Metrics {
+        /// The number of collections within an Azure CosmosDB account.
+        public var collections: Int?
+
+        /// The size of a collection in kilobytes.
+        public var collectionSize: Int?
+
+        /// The number of documents within a collection.
+        public var documents: Int?
+
+        /// The size of a document within a collection.
+        public var documentSize: Int?
+
+        /// The size of all the documents within a collection.
+        public var documentsSize: Int?
+
+        /// The number of user defined functions within a collection.
+        public var functions: Int?
+
+        /// The number of stored procedures within a collection.
+        public var storedProcedures: Int?
+
+        /// The number of triggers within a collection.
+        public var triggers: Int?
+
+        // Metrics("functions=25;storedProcedures=100;triggers=25;documentSize=10240;")
+        fileprivate init(_ metricsString: String) {
+            let keyValuePairs = metricsString.parsedKeyValuePairs()
+            for (key, value) in keyValuePairs {
+                switch key.trimmed {
+                case "collections":
+                    self.collections = value
+                case "collectionSize":
+                    self.collectionSize = value
+                case "documentsCount":
+                    self.documents = value
+                case "documentSize":
+                    self.documentSize = value
+                case "documentsSize":
+                    self.documentsSize = value
+                case "functions":
+                    self.functions = value
+                case "storedProcedures":
+                    self.storedProcedures = value
+                case "triggers":
+                    self.triggers = value
+                default:
+                    break
+                }
+            }
+        }
+    }
+}
+
+// MARK: -
+
+fileprivate extension Dictionary where Key == AnyHashable, Value == Any {
+    subscript(key: MSHttpHeader) -> String? {
+        return self[key.rawValue] as? String
+    }
+
+    subscript(key: MSHttpHeader) -> Int? {
+        return Int((self[key.rawValue] as? String) ?? "")
+    }
+
+    subscript(key: MSHttpHeader) -> Double? {
+        return Double((self[key.rawValue] as? String) ?? "")
+    }
+}
+
+// MARK: -
+
+fileprivate extension StringProtocol {
+    /// "functions=25;storedProcedures=100;"parsedKeyValuePairs() -> [("functions", 25), ("storedProcedures", 100)]
+    func parsedKeyValuePairs() -> [(String, Int)] {
+        return self.split(separator: ";").compactMap { $0.parsedKeyValuePair() }
+    }
+
+    /// "functions=25".parsedKeyValuePairString() -> ("functions", 25)
+    func parsedKeyValuePair() -> (String, Int)? {
+        let pair = self.split(separator: "=")
+        guard pair.count == 2 else { return nil }
+        let key = String(pair[0])
+        guard let value = Int(pair[1]) else { return nil }
+        return (key, value)
+    }
+
+    /// "version=1.6.52.5".valueIfKeyValuePairElseSelf -> "1.6.52.5"
+    /// "1.6.52.5".valueIfKeyValuePairElseSelf -> "1.6.52.5"
+    var valueIfKeyValuePairElseSelf: String {
+        let pair = self.split(separator: "=")
+        guard pair.count == 2 else { return String(self) }
+        return String(pair[1])
+    }
+}
+
+// MARK: -
+
+fileprivate extension String {
+    var trimmed: String {
+        return self.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/AzureData/Source/Response.swift
+++ b/AzureData/Source/Response.swift
@@ -21,7 +21,9 @@ public struct Response<T> {
     public var error: Error? { return result.error }
     
     public var resource: T?  { return result.resource }
-    
+
+    public lazy var metadata: ResponseMetadata? = response.flatMap { ResponseMetadata(for: $0) }
+
     public init(request: URLRequest?, data: Data?, response: HTTPURLResponse?, result: Result<T>) {
         self.request = request
         self.data = data

--- a/AzureData/Tests/ResponseMetadataTests.swift
+++ b/AzureData/Tests/ResponseMetadataTests.swift
@@ -1,0 +1,91 @@
+//
+//  ResponseMetadataTests.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import XCTest
+@testable import AzureData
+@testable import AzureCore
+
+class ResponseMetadataTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testResponseMetadataIsCorrectlyFromHTTPURLResponse() {
+        guard let response = HTTPURLResponse(
+            url: URL(string: "https://ms.portal.azure.com")!,
+            statusCode: 200,
+            httpVersion: "1.1",
+            headerFields: [
+                "Content-Type": "application/json",
+                "etag": "00003200-0000-0000-0000-56f9e84d0000",
+                "x-ms-continuation": "-RID:K0JYAKIH9QADAAAAAAAAAA==#RT:1#TRC:2",
+                "x-ms-item-count": "10",
+                "x-ms-resource-quota": "collections=5000;functions=25;storedProcedures=100;triggers=25;documentsCount=-1;documentSize=10240;documentsSize=10485760;collectionSize=10485760;",
+                "x-ms-resource-usage": "collections=13;functions=5;storedProcedures=10;triggers=2;documentsCount=0;documentSize=0;documentsSize=1;collectionSize=1;",
+                "x-ms-schemaversion": "1.1",
+                "x-ms-alt-content-path": "dbs/testdb/colls/testcoll",
+                "x-ms-request-charge": "12.38",
+                "x-ms-serviceversion": "version=1.6.52.5",
+                "x-ms-activity-id": "856acd38-320d-47df-ab6f-9761bb987668",
+                "x-ms-session-token": "0:603",
+                "x-ms-retry-after-ms": "5000",
+                "Date": "Tue, 29 Mar 2016 02:28:30 GMT"
+            ]
+        ) else {
+                return
+        }
+
+        let metadata = ResponseMetadata(for: response)
+
+        XCTAssertEqual(metadata.activityId, "856acd38-320d-47df-ab6f-9761bb987668")
+        XCTAssertEqual(metadata.alternateContentPath, "dbs/testdb/colls/testcoll")
+        XCTAssertEqual(metadata.contentType, "application/json")
+        XCTAssertEqual(metadata.continuation, "-RID:K0JYAKIH9QADAAAAAAAAAA==#RT:1#TRC:2")
+        XCTAssertNotNil(metadata.date)
+        XCTAssertEqual(DateFormat.getRFC1123Formatter().string(from: metadata.date!), "Tue, 29 Mar 2016 02:28:30 GMT")
+        XCTAssertEqual(metadata.etag, "00003200-0000-0000-0000-56f9e84d0000")
+        XCTAssertEqual(metadata.itemCount, 10)
+        XCTAssertNotNil(metadata.requestCharge)
+        XCTAssertEqual(metadata.requestCharge!, 12.38, accuracy: 0.000000001)
+        XCTAssertEqual(metadata.schemaVersion, "1.1")
+        XCTAssertEqual(metadata.serviceVersion, "1.6.52.5")
+        XCTAssertEqual(metadata.sessionToken, "0:603")
+
+        XCTAssertNotNil(metadata.resourceQuota)
+        let quota = metadata.resourceQuota!
+
+        XCTAssertEqual(quota.collections, 5000)
+        XCTAssertEqual(quota.functions, 25)
+        XCTAssertEqual(quota.storedProcedures, 100)
+        XCTAssertEqual(quota.triggers, 25)
+        XCTAssertEqual(quota.documents, -1)
+        XCTAssertEqual(quota.documentSize, 10240)
+        XCTAssertEqual(quota.documentsSize, 10485760)
+        XCTAssertEqual(quota.collectionSize, 10485760)
+
+        XCTAssertNotNil(metadata.resourceUsage)
+        let usage = metadata.resourceUsage!
+
+        XCTAssertEqual(usage.collections, 13)
+        XCTAssertEqual(usage.functions, 5)
+        XCTAssertEqual(usage.storedProcedures, 10)
+        XCTAssertEqual(usage.triggers, 2)
+        XCTAssertEqual(usage.documents, 0)
+        XCTAssertEqual(usage.documentSize, 0)
+        XCTAssertEqual(usage.documentsSize, 1)
+        XCTAssertEqual(usage.collectionSize, 1)
+
+        XCTAssertNotNil(metadata.retryAfter)
+        XCTAssertEqual(metadata.retryAfter!, 5, accuracy: 0.000000001)
+    }
+}


### PR DESCRIPTION
Fixes #15.

Changes Proposed in this pull request:
- Add Azure CosmosDB related metadata in the `Response` Object.
