### PR TITLE
Add StoredProcedure execute override that takes StoredProcedure object

### DIFF
--- a/AzureData/Source/AzureData.swift
+++ b/AzureData/Source/AzureData.swift
@@ -342,6 +342,10 @@ public func replace (storedProcedureWithId storedProcedureId: String, andBody pr
 }
 
 // execute
+public func execute (_ storedProcedure: StoredProcedure, usingParameters parameters: [String]?, callback: @escaping (Response<Data>) -> ()) {
+    return DocumentClient.shared.execute(storedProcedure, usingParameters: parameters, callback: callback)
+}
+
 public func execute (storedProcedureWithId storedProcedureId: String, usingParameters parameters: [String]?, inCollection collectionId: String, inDatabase databaseId: String, callback: @escaping (Response<Data>) -> ()) {
     return DocumentClient.shared.execute (storedProcedureWithId: storedProcedureId, usingParameters: parameters, inCollection: collectionId, inDatabase: databaseId, callback: callback)
 }

--- a/AzureData/Source/AzureDataExtensions.swift
+++ b/AzureData/Source/AzureDataExtensions.swift
@@ -166,7 +166,7 @@ public extension DocumentCollection {
     
     // execute
     public func execute (_ storedProcedure: StoredProcedure, usingParameters parameters: [String]?, callback: @escaping (Response<Data>) -> ()) {
-        return DocumentClient.shared.execute (storedProcedureWithId: storedProcedure.id, usingParameters: parameters, in: self, callback: callback)
+        return DocumentClient.shared.execute (storedProcedure, usingParameters: parameters, callback: callback)
     }
 
     public func execute (storedProcedureWithId id: String, usingParameters parameters: [String]?, callback: @escaping (Response<Data>) -> ()) {

--- a/AzureData/Source/AzureDataExtensions.swift
+++ b/AzureData/Source/AzureDataExtensions.swift
@@ -165,6 +165,10 @@ public extension DocumentCollection {
     }
     
     // execute
+    public func execute (_ storedProcedure: StoredProcedure, usingParameters parameters: [String]?, callback: @escaping (Response<Data>) -> ()) {
+        return DocumentClient.shared.execute (storedProcedureWithId: storedProcedure.id, usingParameters: parameters, in: self, callback: callback)
+    }
+
     public func execute (storedProcedureWithId id: String, usingParameters parameters: [String]?, callback: @escaping (Response<Data>) -> ()) {
         return DocumentClient.shared.execute (storedProcedureWithId: id, usingParameters: parameters, in: self, callback: callback)
     }
@@ -305,7 +309,15 @@ public extension User {
     }
 }
 
+// MARK: -
 
+public extension StoredProcedure {
+
+    // execute
+    public func execute (usingParameters parameters: [String]?, callback: @escaping (Response<Data>) -> ()) {
+        return DocumentClient.shared.execute(self, usingParameters: parameters, callback: callback)
+    }
+}
 
 
 

--- a/AzureData/Source/DocumentClient.swift
+++ b/AzureData/Source/DocumentClient.swift
@@ -381,6 +381,10 @@ class DocumentClient {
     }
     
     // execute
+    func execute (_ storedProcedure: StoredProcedure, usingParameters parameters: [String]?, callback: @escaping (Response<Data>) -> ()) {
+        return self.execute(StoredProcedure.self, withBody: parameters, at: .resource(resource: storedProcedure), callback: callback)
+    }
+
     func execute (storedProcedureWithId storedProcedureId: String, usingParameters parameters: [String]?, inCollection collectionId: String, inDatabase databaseId: String, callback: @escaping (Response<Data>) -> ()) {
         return self.execute(StoredProcedure.self, withBody: parameters, at: .storedProcedure(databaseId: databaseId, collectionId: collectionId, id: storedProcedureId), callback: callback)
     }

--- a/AzureData/Tests/AzureDataTests.swift
+++ b/AzureData/Tests/AzureDataTests.swift
@@ -72,7 +72,7 @@ class AzureDataTests: XCTestCase {
     lazy var replaceExpectation  = self.expectation(description: "should replace \(rname)")
     lazy var replaceExpectation2 = self.expectation(description: "should replace \(rname)")
     lazy var refreshExpectation  = self.expectation(description: "should refresh \(rname)")
-
+    lazy var executeExpectation  = self.expectation(description: "should execute \(rname)")
     
     override func setUp() {
         super.setUp()

--- a/AzureData/Tests/StoredProcedureTests.swift
+++ b/AzureData/Tests/StoredProcedureTests.swift
@@ -38,6 +38,7 @@ class StoredProcedureTests: AzureDataTests {
         var createResponse:     Response<StoredProcedure>?
         var listResponse:       Response<Resources<StoredProcedure>>?
         var replaceResponse:    Response<StoredProcedure>?
+        var executeResponse:    Response<Data>?
         var deleteResponse:     Response<Data>?
 
         // Create
@@ -71,6 +72,19 @@ class StoredProcedureTests: AzureDataTests {
 
             XCTAssertNotNil(replaceResponse?.resource)
         }
+
+        // Execute
+        if let storedProcedure = createResponse?.resource {
+            AzureData.execute(storedProcedure, usingParameters: []) { r in
+                executeResponse = r
+                self.executeExpectation.fulfill()
+            }
+        }
+
+        wait(for: [executeExpectation], timeout: timeout)
+
+        XCTAssertNotNil(executeResponse)
+        XCTAssertTrue(executeResponse!.result.isSuccess)
 
         // Delete
         if let storedProcedure = replaceResponse?.resource ?? createResponse?.resource {


### PR DESCRIPTION
Fixes #62.

Changes Proposed in this pull request:
- Add `AzureData.execute` override that takes a `StoredProcedure` in parameter.
