### PR TITLE
Restrict Permission create/replace APIs to resources supporting permission token

### DIFF
--- a/AzureData/AzureData.xcodeproj/project.pbxproj
+++ b/AzureData/AzureData.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		323AE94A2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */; };
+		323AE94B2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */; };
+		323AE94C2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */; };
+		323AE94D2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */; };
 		32532A5A207825A1002BFFCA /* ResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32532A59207825A1002BFFCA /* ResponseMetadata.swift */; };
 		32532A5C207825A1002BFFCA /* ResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32532A59207825A1002BFFCA /* ResponseMetadata.swift */; };
 		32532A5E207825A1002BFFCA /* ResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32532A59207825A1002BFFCA /* ResponseMetadata.swift */; };
@@ -276,6 +280,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportsPermissionToken.swift; sourceTree = "<group>"; };
 		32532A59207825A1002BFFCA /* ResponseMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseMetadata.swift; sourceTree = "<group>"; };
 		32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseMetadataTests.swift; sourceTree = "<group>"; };
 		9302CE422059A3A5000F6885 /* AzureCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AzureCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -439,6 +444,7 @@
 				B52240381FB33CD000D0343F /* UtilityExtensions.swift */,
 				B58361B71FBA1339001CEC66 /* Resources */,
 				B55AEFDF1FB34B7400F7BEED /* Supporting Files */,
+				323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -893,6 +899,7 @@
 				B52240B21FB3409000D0343F /* ResourceType.swift in Sources */,
 				9319DEF420698F260083475D /* PermissionProviderError.swift in Sources */,
 				B58361F11FBA19A7001CEC66 /* DatabaseAccount.swift in Sources */,
+				323AE94B2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */,
 				B58361E71FBA17D8001CEC66 /* User.swift in Sources */,
 				B52241051FB3409F00D0343F /* UtilityExtensions.swift in Sources */,
 				9319DF032069DD7B0083475D /* ResourceTokenProvider.swift in Sources */,
@@ -970,6 +977,7 @@
 				B52240C71FB3409100D0343F /* ResourceType.swift in Sources */,
 				9319DEF520698F260083475D /* PermissionProviderError.swift in Sources */,
 				B58361F21FBA19A7001CEC66 /* DatabaseAccount.swift in Sources */,
+				323AE94C2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */,
 				B58361E81FBA17D8001CEC66 /* User.swift in Sources */,
 				B52241001FB3409E00D0343F /* UtilityExtensions.swift in Sources */,
 				9319DF042069DD7B0083475D /* ResourceTokenProvider.swift in Sources */,
@@ -1047,6 +1055,7 @@
 				B52240DC1FB3409200D0343F /* ResourceType.swift in Sources */,
 				9319DEF620698F260083475D /* PermissionProviderError.swift in Sources */,
 				B58361F31FBA19A7001CEC66 /* DatabaseAccount.swift in Sources */,
+				323AE94D2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */,
 				B58361E91FBA17D8001CEC66 /* User.swift in Sources */,
 				B52240FB1FB3409D00D0343F /* UtilityExtensions.swift in Sources */,
 				9319DF052069DD7B0083475D /* ResourceTokenProvider.swift in Sources */,
@@ -1092,6 +1101,7 @@
 				B58361F01FBA19A7001CEC66 /* DatabaseAccount.swift in Sources */,
 				9319DEF320698F260083475D /* PermissionProviderError.swift in Sources */,
 				B522409D1FB3408E00D0343F /* ResourceType.swift in Sources */,
+				323AE94A2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */,
 				B58361E61FBA17D8001CEC66 /* User.swift in Sources */,
 				B58361EB1FBA17E8001CEC66 /* UserDefinedFunction.swift in Sources */,
 				9319DF022069DD7B0083475D /* ResourceTokenProvider.swift in Sources */,

--- a/AzureData/Source/AzureData.swift
+++ b/AzureData/Source/AzureData.swift
@@ -487,11 +487,11 @@ public func replace (userWithId userId: String, with newUserId: String, inDataba
 // MARK: - Permissions
 
 // create
-public func create (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource, forUser userId: String, inDatabase databaseId: String, callback: @escaping (Response<Permission>) -> ()) {
+public func create (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource & SupportsPermissionToken, forUser userId: String, inDatabase databaseId: String, callback: @escaping (Response<Permission>) -> ()) {
     return DocumentClient.shared.create (permissionWithId: permissionId, mode: permissionMode, in: resource, forUser: userId, inDatabase: databaseId, callback: callback)
 }
 
-public func create (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource, forUser user: User, callback: @escaping (Response<Permission>) -> ()) {
+public func create (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource & SupportsPermissionToken, forUser user: User, callback: @escaping (Response<Permission>) -> ()) {
     return DocumentClient.shared.create (permissionWithId: permissionId, mode: permissionMode, in: resource, forUser: user, callback: callback)
 }
 
@@ -523,11 +523,11 @@ public func delete (permissionWithId permissionId: String, fromUser user: User, 
 }
 
 // replace
-public func replace (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource, forUser userId: String, inDatabase databaseId: String, callback: @escaping (Response<Permission>) -> ()) {
+public func replace (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource & SupportsPermissionToken, forUser userId: String, inDatabase databaseId: String, callback: @escaping (Response<Permission>) -> ()) {
     return DocumentClient.shared.replace (permissionWithId: permissionId, mode: permissionMode, in: resource, forUser: userId, inDatabase: databaseId, callback: callback)
 }
 
-public func replace (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource, forUser user: User, callback: @escaping (Response<Permission>) -> ()) {
+public func replace (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource & SupportsPermissionToken, forUser user: User, callback: @escaping (Response<Permission>) -> ()) {
     return DocumentClient.shared.replace (permissionWithId: permissionId, mode: permissionMode, in: resource, forUser: user, callback: callback)
 }
 

--- a/AzureData/Source/AzureDataExtensions.swift
+++ b/AzureData/Source/AzureDataExtensions.swift
@@ -19,13 +19,15 @@ public extension CodableResource {
     public func refresh(_ callback: @escaping (Response<Self>) -> ()) {
         return DocumentClient.shared.refresh(self, callback: callback)
     }
+}
+
+public extension CodableResource where Self: SupportsPermissionToken {
 
     public func create(permissionWithId permissionId: String, mode permissionMode: PermissionMode, forUser user: User, callback: @escaping (Response<Permission>) -> ()) {
         return DocumentClient.shared.create(permissionWithId: permissionId, mode: permissionMode, in: self, forUser: user, callback: callback)
     }
+
 }
-
-
 
 // MARK: -
 
@@ -276,7 +278,7 @@ public extension User {
     // MARK: Permissions
     
     // create
-    public func create (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource, callback: @escaping (Response<Permission>) -> ()) {
+    public func create (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource & SupportsPermissionToken, callback: @escaping (Response<Permission>) -> ()) {
         return DocumentClient.shared.create (permissionWithId: permissionId, mode: permissionMode, in: resource, forUser: self, callback: callback)
     }
     
@@ -300,7 +302,7 @@ public extension User {
     }
 
     // replace
-    public func replace (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource, callback: @escaping (Response<Permission>) -> ()) {
+    public func replace (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource & SupportsPermissionToken, callback: @escaping (Response<Permission>) -> ()) {
         return DocumentClient.shared.replace (permissionWithId: permissionId, mode: permissionMode, in: resource, forUser: self, callback: callback)
     }
 }

--- a/AzureData/Source/DocumentClient.swift
+++ b/AzureData/Source/DocumentClient.swift
@@ -529,11 +529,11 @@ class DocumentClient {
     // MARK: - Permissions
     
     // create
-    func create (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource, forUser userId: String, inDatabase databaseId: String, callback: @escaping (Response<Permission>) -> ()) {
+    func create (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource & SupportsPermissionToken, forUser userId: String, inDatabase databaseId: String, callback: @escaping (Response<Permission>) -> ()) {
         return self.create(Permission(permissionId, mode: permissionMode, forResource: resource.selfLink!), at: .permission(databaseId: databaseId, userId: userId, id: nil), callback: callback)
     }
     
-    func create (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource, forUser user: User, callback: @escaping (Response<Permission>) -> ()) {
+    func create (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource & SupportsPermissionToken, forUser user: User, callback: @escaping (Response<Permission>) -> ()) {
         return self.create(Permission(permissionId, mode: permissionMode, forResource: resource.selfLink!), at: .child(.permission, in: user, id: nil), callback: callback)
     }
     
@@ -565,11 +565,11 @@ class DocumentClient {
     }
     
     // replace
-    func replace (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource, forUser userId: String, inDatabase databaseId: String, callback: @escaping (Response<Permission>) -> ()) {
+    func replace (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource & SupportsPermissionToken, forUser userId: String, inDatabase databaseId: String, callback: @escaping (Response<Permission>) -> ()) {
         return self.replace(Permission(permissionId, mode: permissionMode, forResource: resource.selfLink!), at: .permission(databaseId: databaseId, userId: userId, id: permissionId), callback: callback)
     }
     
-    func replace (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource, forUser user: User, callback: @escaping (Response<Permission>) -> ()) {
+    func replace (permissionWithId permissionId: String, mode permissionMode: PermissionMode, in resource: CodableResource & SupportsPermissionToken, forUser user: User, callback: @escaping (Response<Permission>) -> ()) {
         return self.replace(Permission(permissionId, mode: permissionMode, forResource: resource.selfLink!), at: .child(.permission, in: user, id: permissionId), callback: callback)
     }
     

--- a/AzureData/Source/Resources/Attachment.swift
+++ b/AzureData/Source/Resources/Attachment.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Represents a document attachment in the Azure Cosmos DB service.
-public struct Attachment : CodableResource {
+public struct Attachment : CodableResource, SupportsPermissionToken {
     
     public static var type = "attachments"
     public static var list = "Attachments"

--- a/AzureData/Source/Resources/Document.swift
+++ b/AzureData/Source/Resources/Document.swift
@@ -14,7 +14,7 @@ import Foundation
 ///   A document is a structured JSON document. There is no set schema for the JSON documents,
 ///   and a document may contain any number of custom properties as well as an optional list of attachments.
 ///   Document is an application resource and can be authorized using the master key or resource keys.
-open class Document : CodableResource, CustomDebugStringConvertible {
+open class Document : CodableResource, SupportsPermissionToken, CustomDebugStringConvertible {
 
     public static var type = "docs"
     public static var list = "Documents"

--- a/AzureData/Source/Resources/DocumentCollection.swift
+++ b/AzureData/Source/Resources/DocumentCollection.swift
@@ -16,7 +16,7 @@ import Foundation
 ///   Being schema-free, the documents in a collection do not need to share the same structure or fields.
 ///   Since collections are application resources, they can be authorized using either the master key or resource keys.
 ///   Refer to [collections](http://azure.microsoft.com/documentation/articles/documentdb-resources/#collections) for more details on collections.
-public struct DocumentCollection : CodableResource {
+public struct DocumentCollection : CodableResource, SupportsPermissionToken {
     
     public static var type = "colls"
     public static var list = "DocumentCollections"

--- a/AzureData/Source/Resources/StoredProcedure.swift
+++ b/AzureData/Source/Resources/StoredProcedure.swift
@@ -14,7 +14,7 @@ import Foundation
 ///   Azure Cosmos DB allows application logic written entirely in JavaScript to be executed directly inside
 ///   the database engine under the database transaction.
 ///   For additional details, refer to the server-side JavaScript API documentation.
-public struct StoredProcedure : CodableResource {
+public struct StoredProcedure : CodableResource, SupportsPermissionToken {
     
     public static var type = "sprocs"
     public static var list = "StoredProcedures"

--- a/AzureData/Source/Resources/Trigger.swift
+++ b/AzureData/Source/Resources/Trigger.swift
@@ -13,7 +13,7 @@ import Foundation
 /// - Remark:
 ///   Azure Cosmos DB supports pre and post triggers written in JavaScript to be executed on creates, updates and deletes.
 ///   For additional details, refer to the server-side JavaScript API documentation.
-public struct Trigger : CodableResource {
+public struct Trigger : CodableResource, SupportsPermissionToken {
     
     public static var type = "triggers"
     public static var list = "Triggers"

--- a/AzureData/Source/Resources/UserDefinedFunction.swift
+++ b/AzureData/Source/Resources/UserDefinedFunction.swift
@@ -15,7 +15,7 @@ import Foundation
 ///   the database and can be used inside queries.
 ///   Refer to [javascript-integration](http://azure.microsoft.com/documentation/articles/documentdb-sql-query/#javascript-integration) for how to use UDFs within queries.
 ///   Refer to [udf](http://azure.microsoft.com/documentation/articles/documentdb-programming/#udf) for more details about implementing UDFs in JavaScript.
-public struct UserDefinedFunction : CodableResource {
+public struct UserDefinedFunction : CodableResource, SupportsPermissionToken {
     
     public static var type = "udfs"
     public static var list = "UserDefinedFunctions"

--- a/AzureData/Source/SupportsPermissionToken.swift
+++ b/AzureData/Source/SupportsPermissionToken.swift
@@ -1,0 +1,11 @@
+//
+//  SupportsPermissionToken.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+public protocol SupportsPermissionToken {}


### PR DESCRIPTION
Fixes #63.

Changes Proposed in this pull request:
- Restrict Permission create/replace APIs to resources supporting permission token 
