### PR TITLE
Review offline caching and add tests

### DIFF
--- a/AzureCore/AzureCore.xcodeproj/project.pbxproj
+++ b/AzureCore/AzureCore.xcodeproj/project.pbxproj
@@ -11,6 +11,10 @@
 		3259AE80206C5519002EF09B /* KeychainAccess.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3259AE7F206C5519002EF09B /* KeychainAccess.framework */; };
 		3259AE82206C5523002EF09B /* KeychainAccess.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3259AE81206C5523002EF09B /* KeychainAccess.framework */; };
 		3259AE84206C5531002EF09B /* KeychainAccess.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3259AE83206C5531002EF09B /* KeychainAccess.framework */; };
+		3276EA17208F3D91003F6382 /* ReachabilityManagerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3276EA16208F3D91003F6382 /* ReachabilityManagerType.swift */; };
+		3276EA18208F3D91003F6382 /* ReachabilityManagerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3276EA16208F3D91003F6382 /* ReachabilityManagerType.swift */; };
+		3276EA19208F3D91003F6382 /* ReachabilityManagerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3276EA16208F3D91003F6382 /* ReachabilityManagerType.swift */; };
+		3276EA1A208F3D91003F6382 /* ReachabilityManagerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3276EA16208F3D91003F6382 /* ReachabilityManagerType.swift */; };
 		930A01BB202BB95E002BD1FE /* AzureCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 93F8054B202BB20300D0B4F4 /* AzureCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		930A01F8202BBA09002BD1FE /* AzureCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 930A01EF202BBA09002BD1FE /* AzureCore.framework */; };
 		930A0243202BBB3F002BD1FE /* AzureCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 93F8054B202BB20300D0B4F4 /* AzureCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -95,6 +99,7 @@
 		3259AE7F206C5519002EF09B /* KeychainAccess.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = KeychainAccess.framework; path = Carthage/Build/Mac/KeychainAccess.framework; sourceTree = "<group>"; };
 		3259AE81206C5523002EF09B /* KeychainAccess.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = KeychainAccess.framework; path = Carthage/Build/tvOS/KeychainAccess.framework; sourceTree = "<group>"; };
 		3259AE83206C5531002EF09B /* KeychainAccess.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = KeychainAccess.framework; path = Carthage/Build/watchOS/KeychainAccess.framework; sourceTree = "<group>"; };
+		3276EA16208F3D91003F6382 /* ReachabilityManagerType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReachabilityManagerType.swift; sourceTree = "<group>"; };
 		930A01EF202BBA09002BD1FE /* AzureCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AzureCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		930A01F7202BBA09002BD1FE /* AzureCore tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AzureCore tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		930A020B202BBA16002BD1FE /* AzureCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AzureCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -245,6 +250,7 @@
 				93426C8220641ED200AA27C5 /* HttpStatusCode.swift */,
 				935410D1206ECFC5004B20B9 /* Keychain.swift */,
 				93DA941E20634C5500C49122 /* Logger.swift */,
+				3276EA16208F3D91003F6382 /* ReachabilityManagerType.swift */,
 				932F01372077C318001D708B /* ReachabilityManager.swift */,
 				930A01B6202BB910002BD1FE /* Supporting Files */,
 			);
@@ -700,6 +706,7 @@
 				93B72412206486FC00984CA8 /* DateFormat.swift in Sources */,
 				93DA942120634C5500C49122 /* Logger.swift in Sources */,
 				935410D4206ECFC5004B20B9 /* Keychain.swift in Sources */,
+				3276EA19208F3D91003F6382 /* ReachabilityManagerType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -724,6 +731,7 @@
 				93B72413206486FC00984CA8 /* DateFormat.swift in Sources */,
 				93DA942220634C5500C49122 /* Logger.swift in Sources */,
 				935410D5206ECFC5004B20B9 /* Keychain.swift in Sources */,
+				3276EA1A208F3D91003F6382 /* ReachabilityManagerType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -739,6 +747,7 @@
 				93B72410206486FC00984CA8 /* DateFormat.swift in Sources */,
 				93DA941F20634C5500C49122 /* Logger.swift in Sources */,
 				935410D2206ECFC5004B20B9 /* Keychain.swift in Sources */,
+				3276EA17208F3D91003F6382 /* ReachabilityManagerType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -763,6 +772,7 @@
 				93B72411206486FC00984CA8 /* DateFormat.swift in Sources */,
 				93DA942020634C5500C49122 /* Logger.swift in Sources */,
 				935410D3206ECFC5004B20B9 /* Keychain.swift in Sources */,
+				3276EA18208F3D91003F6382 /* ReachabilityManagerType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AzureCore/Source/ReachabilityManager.swift
+++ b/AzureCore/Source/ReachabilityManager.swift
@@ -30,73 +30,32 @@
 import Foundation
 import SystemConfiguration
 
-/// The `Reachability` class listens for reachability changes of hosts and addresses for both WWAN and
-/// WiFi network interfaces.
-///
-/// ReachabilityManager can be used to determine background information about why a network operation failed, or to retry
-/// network requests when a connection is established. It should not be used to prevent a user from initiating a network
-/// request, as it's possible that an initial request may be required to establish reachability.
-public class ReachabilityManager {
-    /// Defines the various states of network reachability.
-    ///
-    /// - unknown:      It is unknown whether the network is reachable.
-    /// - notReachable: The network is not reachable.
-    /// - reachable:    The network is reachable.
-    public enum NetworkReachabilityStatus {
-        case unknown
-        case notReachable
-        case reachable(ConnectionType)
-    }
-    
-    /// Defines the various connection types detected by reachability flags.
-    ///
-    /// - ethernetOrWiFi: The connection type is either over Ethernet or WiFi.
-    /// - wwan:           The connection type is a WWAN connection.
-    public enum ConnectionType {
-        case ethernetOrWiFi
-        case wwan
-    }
-    
-    /// A closure executed when the network reachability status changes. The closure takes a single argument: the
-    /// network reachability status.
-    public typealias Listener = (NetworkReachabilityStatus) -> Void
-    
+public class ReachabilityManager: ReachabilityManagerType {
+
     // MARK: - Properties
-    
-    /// Whether the network is currently reachable.
-    public var isReachable: Bool { return isReachableOnWWAN || isReachableOnEthernetOrWiFi }
-    
-    /// Whether the network is currently reachable over the WWAN interface.
-    public var isReachableOnWWAN: Bool { return networkReachabilityStatus == .reachable(.wwan) }
-    
-    /// Whether the network is currently reachable over Ethernet or WiFi interface.
-    public var isReachableOnEthernetOrWiFi: Bool { return networkReachabilityStatus == .reachable(.ethernetOrWiFi) }
-    
-    /// The current network reachability status.
+
     public var networkReachabilityStatus: NetworkReachabilityStatus {
         guard let flags = self.flags else { return .unknown }
         return networkReachabilityStatusForFlags(flags)
     }
-    
+
     /// The dispatch queue to execute the `listener` closure on.
-    public var listenerQueue: DispatchQueue = DispatchQueue.main
-    
-    /// A closure executed when the network reachability status changes.
-    public var listener: Listener?
-    
-    public var flags: SCNetworkReachabilityFlags? {
+    private var listenerQueue: DispatchQueue = DispatchQueue.main
+
+    internal var listener: ReachabilityStatusListener?
+
+    private let reachability: SCNetworkReachability
+    private var previousFlags: SCNetworkReachabilityFlags
+    private var flags: SCNetworkReachabilityFlags? {
         var flags = SCNetworkReachabilityFlags()
-        
+
         if SCNetworkReachabilityGetFlags(reachability, &flags) {
             return flags
         }
-        
+
         return nil
     }
-    
-    private let reachability: SCNetworkReachability
-    public var previousFlags: SCNetworkReachabilityFlags
-    
+
     // MARK: - Initialization
     
     /// Creates a `Reachability` instance with the specified host.
@@ -139,10 +98,11 @@ public class ReachabilityManager {
     }
     
     // MARK: - Listening
-    
-    /// Starts listening for changes in network reachability status.
-    ///
-    /// - returns: `true` if listening was started successfully, `false` otherwise.
+
+    public func registerListener(_ listener: @escaping ReachabilityStatusListener) {
+        self.listener = listener
+    }
+
     @discardableResult
     public func startListening() -> Bool {
         var context = SCNetworkReachabilityContext(version: 0, info: nil, retain: nil, release: nil, copyDescription: nil)
@@ -167,7 +127,6 @@ public class ReachabilityManager {
         return callbackEnabled && queueEnabled
     }
     
-    /// Stops listening for changes in network reachability status.
     public func stopListening() {
         SCNetworkReachabilitySetCallback(reachability, nil, nil)
         SCNetworkReachabilitySetDispatchQueue(reachability, nil)
@@ -203,33 +162,6 @@ public class ReachabilityManager {
         let canConnectWithoutUserInteraction = canConnectAutomatically && !flags.contains(.interventionRequired)
         
         return isReachable && (!needsConnection || canConnectWithoutUserInteraction)
-    }
-}
-
-// MARK: -
-
-extension ReachabilityManager.NetworkReachabilityStatus: Equatable {}
-
-/// Returns whether the two network reachability status values are equal.
-///
-/// - parameter lhs: The left-hand side value to compare.
-/// - parameter rhs: The right-hand side value to compare.
-///
-/// - returns: `true` if the two values are equal, `false` otherwise.
-public func ==(
-    lhs: ReachabilityManager.NetworkReachabilityStatus,
-    rhs: ReachabilityManager.NetworkReachabilityStatus)
-    -> Bool
-{
-    switch (lhs, rhs) {
-    case (.unknown, .unknown):
-        return true
-    case (.notReachable, .notReachable):
-        return true
-    case let (.reachable(lhsConnectionType), .reachable(rhsConnectionType)):
-        return lhsConnectionType == rhsConnectionType
-    default:
-        return false
     }
 }
 

--- a/AzureCore/Source/ReachabilityManagerType.swift
+++ b/AzureCore/Source/ReachabilityManagerType.swift
@@ -1,0 +1,105 @@
+//
+//  ReachabilityManagerType.swift
+//  AzureCore
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+#if !os(watchOS)
+
+import Foundation
+import SystemConfiguration
+
+/// Defines the various connection types detected by reachability flags.
+///
+/// - ethernetOrWiFi: The connection type is either over Ethernet or WiFi.
+/// - wwan:           The connection type is a WWAN connection.
+public enum ConnectionType {
+    case ethernetOrWiFi
+    case wwan
+}
+
+/// Defines the various states of network reachability.
+///
+/// - unknown:      It is unknown whether the network is reachable.
+/// - notReachable: The network is not reachable.
+/// - reachable:    The network is reachable.
+public enum NetworkReachabilityStatus {
+    case unknown
+    case notReachable
+    case reachable(ConnectionType)
+}
+
+/// A closure executed when the network reachability status changes. The closure takes a single argument: the
+/// network reachability status.
+public typealias ReachabilityStatusListener = (NetworkReachabilityStatus) -> Void
+
+/// The `ReachabilityManagerType` describes entities that listen for reachability changes of hosts and addresses for both WWAN and
+/// WiFi network interfaces.
+///
+/// They can be used to determine background information about why a network operation failed, or to retry
+/// network requests when a connection is established. It should not be used to prevent a user from initiating a network
+/// request, as it's possible that an initial request may be required to establish reachability.
+public protocol ReachabilityManagerType {
+    /// The current network reachability status.
+    var networkReachabilityStatus: NetworkReachabilityStatus { get }
+
+    /// Sets a closure executed when the network reachability status changes.
+    func registerListener(_ listener: @escaping ReachabilityStatusListener)
+
+    /// Starts listening for changes in network reachability status.
+    ///
+    /// - returns: `true` if listening was started successfully, `false` otherwise.
+    @discardableResult
+    func startListening() -> Bool
+
+    /// Stops listening for changes in network reachability status.
+    func stopListening()
+}
+
+public extension ReachabilityManagerType {
+    /// Whether the network is currently reachable.
+    var isReachable: Bool {
+        return isReachableOnWWAN || isReachableOnEthernetOrWiFi
+    }
+
+    /// Whether the network is currently reachable over the WWAN interface.
+    var isReachableOnWWAN: Bool {
+        return networkReachabilityStatus == .reachable(.wwan)
+    }
+
+    /// Whether the network is currently reachable over Ethernet or WiFi interface.
+    var isReachableOnEthernetOrWiFi: Bool {
+        return networkReachabilityStatus == .reachable(.ethernetOrWiFi)
+    }
+}
+
+// MARK: -
+
+extension NetworkReachabilityStatus: Equatable {}
+
+/// Returns whether the two network reachability status values are equal.
+///
+/// - parameter lhs: The left-hand side value to compare.
+/// - parameter rhs: The right-hand side value to compare.
+///
+/// - returns: `true` if the two values are equal, `false` otherwise.
+public func ==(
+    lhs: NetworkReachabilityStatus,
+    rhs: NetworkReachabilityStatus)
+    -> Bool
+{
+    switch (lhs, rhs) {
+    case (.unknown, .unknown):
+        return true
+    case (.notReachable, .notReachable):
+        return true
+    case let (.reachable(lhsConnectionType), .reachable(rhsConnectionType)):
+        return lhsConnectionType == rhsConnectionType
+    default:
+        return false
+    }
+}
+
+#endif

--- a/AzureCore/Tests/ReachabilityManagerTests.swift
+++ b/AzureCore/Tests/ReachabilityManagerTests.swift
@@ -117,7 +117,7 @@ class ReachabilityManagerTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "listener closure should be executed")
-        var networkReachabilityStatus: ReachabilityManager.NetworkReachabilityStatus?
+        var networkReachabilityStatus: NetworkReachabilityStatus?
         
         manager.listener = { status in
             guard networkReachabilityStatus == nil else { return }
@@ -138,7 +138,7 @@ class ReachabilityManagerTests: XCTestCase {
         let manager = ReachabilityManager()
         let expectation = self.expectation(description: "listener closure should be executed")
         
-        var networkReachabilityStatus: ReachabilityManager.NetworkReachabilityStatus?
+        var networkReachabilityStatus: NetworkReachabilityStatus?
         
         manager?.listener = { status in
             networkReachabilityStatus = status

--- a/AzureData/AzureData.xcodeproj/project.pbxproj
+++ b/AzureData/AzureData.xcodeproj/project.pbxproj
@@ -7,10 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		323AE94A2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */; };
-		323AE94B2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */; };
-		323AE94C2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */; };
-		323AE94D2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */; };
+		3236FBDD209160F70002FB5F /* _AzureDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3236FBDC209160F70002FB5F /* _AzureDataTests.swift */; };
+		3236FBDE209160F70002FB5F /* _AzureDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3236FBDC209160F70002FB5F /* _AzureDataTests.swift */; };
+		3236FBDF209160F70002FB5F /* _AzureDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3236FBDC209160F70002FB5F /* _AzureDataTests.swift */; };
 		323A90E9207F976400537769 /* CodableResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323A90E8207F976400537769 /* CodableResources.swift */; };
 		323A90EA207F976400537769 /* CodableResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323A90E8207F976400537769 /* CodableResources.swift */; };
 		323A90EB207F976400537769 /* CodableResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323A90E8207F976400537769 /* CodableResources.swift */; };
@@ -18,6 +17,10 @@
 		323A90F220800DEB00537769 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323A90F120800DEB00537769 /* Extensions.swift */; };
 		323A90F320800DEB00537769 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323A90F120800DEB00537769 /* Extensions.swift */; };
 		323A90F520800E6C00537769 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323A90F120800DEB00537769 /* Extensions.swift */; };
+		323AE94A2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */; };
+		323AE94B2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */; };
+		323AE94C2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */; };
+		323AE94D2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */; };
 		323B71AA207E6B75000F20F6 /* ResourceRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323B71A9207E6B75000F20F6 /* ResourceRequestError.swift */; };
 		323B71AB207E6B75000F20F6 /* ResourceRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323B71A9207E6B75000F20F6 /* ResourceRequestError.swift */; };
 		323B71AC207E6B75000F20F6 /* ResourceRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323B71A9207E6B75000F20F6 /* ResourceRequestError.swift */; };
@@ -26,6 +29,9 @@
 		32532A5C207825A1002BFFCA /* ResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32532A59207825A1002BFFCA /* ResponseMetadata.swift */; };
 		32532A5E207825A1002BFFCA /* ResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32532A59207825A1002BFFCA /* ResponseMetadata.swift */; };
 		32532A60207825A1002BFFCA /* ResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32532A59207825A1002BFFCA /* ResponseMetadata.swift */; };
+		3276EA13208F3450003F6382 /* OfflineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3276EA12208F3450003F6382 /* OfflineTests.swift */; };
+		3276EA14208F3450003F6382 /* OfflineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3276EA12208F3450003F6382 /* OfflineTests.swift */; };
+		3276EA15208F3450003F6382 /* OfflineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3276EA12208F3450003F6382 /* OfflineTests.swift */; };
 		32AD4619207976AB00A0D02F /* ResponseMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */; };
 		32AD461A207976AB00A0D02F /* ResponseMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */; };
 		32AD461B207976AB00A0D02F /* ResponseMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */; };
@@ -291,11 +297,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportsPermissionToken.swift; sourceTree = "<group>"; };
+		3236FBDC209160F70002FB5F /* _AzureDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _AzureDataTests.swift; sourceTree = "<group>"; };
 		323A90E8207F976400537769 /* CodableResources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableResources.swift; sourceTree = "<group>"; };
 		323A90F120800DEB00537769 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportsPermissionToken.swift; sourceTree = "<group>"; };
 		323B71A9207E6B75000F20F6 /* ResourceRequestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceRequestError.swift; sourceTree = "<group>"; };
 		32532A59207825A1002BFFCA /* ResponseMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseMetadata.swift; sourceTree = "<group>"; };
+		3276EA12208F3450003F6382 /* OfflineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineTests.swift; sourceTree = "<group>"; };
 		32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseMetadataTests.swift; sourceTree = "<group>"; };
 		9302CE422059A3A5000F6885 /* AzureCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AzureCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9302CE442059A3C5000F6885 /* AzureCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AzureCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -474,6 +482,7 @@
 				B55AEFE01FB34B8C00F7BEED /* Supporting Files */,
 				931EA5C01FBE2775003CCFF4 /* CodableResourceTests.swift */,
 				93F7CA17206EDBC100D92C2E /* PermissionCacheTests.swift */,
+				3236FBDC209160F70002FB5F /* _AzureDataTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -534,6 +543,7 @@
 			children = (
 				B522403D1FB33D1200D0343F /* QueryTests.swift */,
 				32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */,
+				3276EA12208F3450003F6382 /* OfflineTests.swift */,
 			);
 			name = Domain;
 			sourceTree = "<group>";
@@ -956,10 +966,12 @@
 				932832E72072CD9E0075ECC7 /* ExamplePermissionProviderTests.swift in Sources */,
 				B522406E1FB33DF800D0343F /* TriggerTests.swift in Sources */,
 				9317A81D2065763700338B63 /* ResourceOracleTests.swift in Sources */,
+				3276EA14208F3450003F6382 /* OfflineTests.swift in Sources */,
 				B52240701FB33DF800D0343F /* PermissionTests.swift in Sources */,
 				B52240681FB33DF800D0343F /* StoredProcedureTests.swift in Sources */,
 				B52240771FB33DF800D0343F /* AzureDataTests.swift in Sources */,
 				B522406A1FB33DF800D0343F /* QueryTests.swift in Sources */,
+				3236FBDE209160F70002FB5F /* _AzureDataTests.swift in Sources */,
 				B52240781FB33DF800D0343F /* DocumentCollectionTests.swift in Sources */,
 				B52240791FB33DF800D0343F /* OfferTests.swift in Sources */,
 				B522407A1FB33DF800D0343F /* DocumentAttachmentExtensionsTests.swift in Sources */,
@@ -1037,10 +1049,12 @@
 				932832E82072CD9E0075ECC7 /* ExamplePermissionProviderTests.swift in Sources */,
 				B52240821FB33DFA00D0343F /* TriggerTests.swift in Sources */,
 				9317A81E2065763700338B63 /* ResourceOracleTests.swift in Sources */,
+				3276EA15208F3450003F6382 /* OfflineTests.swift in Sources */,
 				B52240841FB33DFA00D0343F /* PermissionTests.swift in Sources */,
 				B522407C1FB33DFA00D0343F /* StoredProcedureTests.swift in Sources */,
 				B522408B1FB33DFA00D0343F /* AzureDataTests.swift in Sources */,
 				B522407E1FB33DFA00D0343F /* QueryTests.swift in Sources */,
+				3236FBDF209160F70002FB5F /* _AzureDataTests.swift in Sources */,
 				B522408C1FB33DFA00D0343F /* DocumentCollectionTests.swift in Sources */,
 				B522408D1FB33DFA00D0343F /* OfferTests.swift in Sources */,
 				B522408E1FB33DFA00D0343F /* DocumentAttachmentExtensionsTests.swift in Sources */,
@@ -1166,10 +1180,12 @@
 				932832E62072CD9E0075ECC7 /* ExamplePermissionProviderTests.swift in Sources */,
 				B522405A1FB33DF100D0343F /* TriggerTests.swift in Sources */,
 				9317A81C2065763700338B63 /* ResourceOracleTests.swift in Sources */,
+				3276EA13208F3450003F6382 /* OfflineTests.swift in Sources */,
 				B522405C1FB33DF100D0343F /* PermissionTests.swift in Sources */,
 				B52240541FB33DF100D0343F /* StoredProcedureTests.swift in Sources */,
 				B52240631FB33DF100D0343F /* AzureDataTests.swift in Sources */,
 				B52240561FB33DF100D0343F /* QueryTests.swift in Sources */,
+				3236FBDD209160F70002FB5F /* _AzureDataTests.swift in Sources */,
 				B52240641FB33DF100D0343F /* DocumentCollectionTests.swift in Sources */,
 				B52240651FB33DF100D0343F /* OfferTests.swift in Sources */,
 				B52240661FB33DF100D0343F /* DocumentAttachmentExtensionsTests.swift in Sources */,

--- a/AzureData/Source/ResourceCache.swift
+++ b/AzureData/Source/ResourceCache.swift
@@ -9,11 +9,13 @@
 import Foundation
 import AzureCore
 
+
 public class ResourceCache {
-    
+
+    // MARK: - Properties
+
     static var isEnabled = true
-    
-    
+
     static let jsonEncoder: JSONEncoder = {
         
         let encoder = JSONEncoder()
@@ -22,7 +24,7 @@ public class ResourceCache {
         
         return encoder
     }()
-    
+
     static let jsonDecoder: JSONDecoder = {
         
         let decoder = JSONDecoder()
@@ -32,10 +34,11 @@ public class ResourceCache {
         return decoder
     }()
 
-    
     static var dispatchQueue: DispatchQueue { return DispatchQueue.global(qos: .default) }
-    
-    
+
+
+    // MARK: -
+
     static func _cache<T:CodableResource>(_ resource: T) {
         
         guard isEnabled else { return }
@@ -43,7 +46,7 @@ public class ResourceCache {
         dispatchQueue.async {
             do {
                 let json = try jsonEncoder.encode(resource)
-                
+
                 try FileManager.default.cache(json, at: ResourceOracle.getFilePath(forResource: resource))
                 
             } catch {
@@ -88,7 +91,7 @@ public class ResourceCache {
         
         do {
             if let file = try FileManager.default.file(at: ResourceOracle.getFilePath(forResourceAt: location)) {
-                
+
                 return try jsonDecoder.decode(T.self, from: file)
             }
         } catch {

--- a/AzureData/Source/ResourceOracle.swift
+++ b/AzureData/Source/ResourceOracle.swift
@@ -264,20 +264,18 @@ public class ResourceOracle {
     }
 
     public static func getDirectoryPath(forResourceAt location: ResourceLocation) -> (path:String, resourceId: String)? {
-        
-        guard
-            let selfLink = getSelfLink(forResourceAt: location),
-            let resourceId = getResourceId(forResourceAt: location, withSelfLink: selfLink)
-        else { return (location.type, "") }
-        
+
+        guard let selfLink = getSelfLink(forResourceAt: location) else { return (location.type, "") }
+
+        let resourceId = getResourceId(forResourceAt: location, withSelfLink: selfLink)
+
         if location.isFeed {
-            return (selfLink + "/" + location.type, resourceId)
+            return (selfLink + "/" + location.type, resourceId.valueOrEmpty)
         }
-        
-        return (selfLink, resourceId)
+
+        return (selfLink, resourceId.valueOrEmpty)
     }
 
-    
     public static func printDump() {
         Log.debug("************************************************************")
         Log.debug("************************************************************")

--- a/AzureData/Source/Response.swift
+++ b/AzureData/Source/Response.swift
@@ -27,13 +27,14 @@ public struct Response<T> {
 
     public lazy var metadata: ResponseMetadata? = response.flatMap { ResponseMetadata(for: $0) }
 
-    public init(request: URLRequest?, data: Data?, response: HTTPURLResponse?, result: Result<T>) {
+    public init(request: URLRequest?, data: Data?, response: HTTPURLResponse?, result: Result<T>, fromCache: Bool = false) {
         self.request = request
         self.data = data
         self.response = response
         self.result = result
+        self.fromCache = fromCache
     }
-    
+
     public init (_ resource: T) {
         self.init(request: nil, data: nil, response: nil, result: .success(resource))
     }

--- a/AzureData/Tests/Extensions.swift
+++ b/AzureData/Tests/Extensions.swift
@@ -18,6 +18,14 @@ extension Optional where Wrapped == DocumentClientError {
         return true
     }
 
+    var isNotFoundError: Bool {
+        guard let errorKind = self?.kind, case .notFound = errorKind else {
+            return false
+        }
+
+        return true
+    }
+
     func isInvalidHeaderError(forHeader header: MSHttpHeader, withMessage message: String) -> Bool {
         guard let errorKind = self?.kind else { return false }
 

--- a/AzureData/Tests/Info.plist
+++ b/AzureData/Tests/Info.plist
@@ -22,5 +22,9 @@
 	<string>AZURE_COSMOS_DB_ACCOUNT_NAME</string>
 	<key>ADDatabaseAccountKey</key>
 	<string>AZURE_COSMOS_DB_ACCOUNT_KEY</string>
+    <key>LSSupportsOpeningDocumentsInPlace</key>
+    <string>YES</string>
+    <key>UIFileSharingEnabled</key>
+    <string>YES</string>
 </dict>
 </plist>

--- a/AzureData/Tests/OfflineTests.swift
+++ b/AzureData/Tests/OfflineTests.swift
@@ -1,0 +1,380 @@
+//
+//  OfflineTests.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import XCTest
+@testable import AzureCore
+@testable import AzureData
+
+#if !os(watchOS)
+
+class OfflineTests: _AzureDataTests {
+
+    // MARK: - Properties
+
+    private let cacheOperationDuration = 2.0
+    private let queue = DispatchQueue(label: "com.azure.data")
+    private let cachesDirectoryURL = try! URL(string: "com.azure.data/", relativeTo: FileManager.default.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: false))!
+    private var reachabilityManager = MockReachabilityManager(.reachable(.ethernetOrWiFi))
+
+    // MARK: -
+
+    override func setUp() {
+        resourceName = "Offline"
+        reachabilityManager = MockReachabilityManager(.reachable(.ethernetOrWiFi))
+        DocumentClient.shared.reachabilityManager = reachabilityManager
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    // MARK: -
+
+    func testFromCacheIsSetToTrueForResourcesFetchedFromLocalCache() {
+        ensureDatabaseExists()
+        let fromCacheExpectation = self.expectation(description: "fromCache should be set to true for resources fetched from the cache")
+
+        reachabilityManager.networkReachabilityStatus = .notReachable
+
+        AzureData.databases { r in
+            XCTAssertTrue(r.result.isSuccess)
+            XCTAssertTrue(r.fromCache)
+
+            self.purgeCache()
+
+            fromCacheExpectation.fulfill()
+        }
+
+        wait(for: [fromCacheExpectation], timeout: timeout)
+    }
+
+    func testFromCacheIsSetToFalseForResourcesFetchedOnline() {
+        ensureDatabaseExists()
+        let fromCacheExpectation = self.expectation(description: "fromCache should be set to false for resources fetched online")
+
+        reachabilityManager.networkReachabilityStatus = .reachable(.ethernetOrWiFi)
+
+        AzureData.databases { r in
+            XCTAssertTrue(r.result.isSuccess)
+            XCTAssertFalse(r.fromCache)
+
+            self.purgeCache()
+
+            fromCacheExpectation.fulfill()
+        }
+
+        wait(for: [fromCacheExpectation], timeout: timeout)
+    }
+
+    func testFromCacheIsSetToTrueForAResourceFetchedFromLocalCache() {
+        ensureDatabaseExists()
+        let fromCacheExpectation = self.expectation(description: "fromCache should be set to true for a resource fetched from the cache")
+
+        reachabilityManager.networkReachabilityStatus = .notReachable
+
+        AzureData.get(databaseWithId: databaseId) { r in
+            XCTAssertTrue(r.result.isSuccess)
+            XCTAssertTrue(r.fromCache)
+
+            self.purgeCache()
+
+            fromCacheExpectation.fulfill()
+        }
+
+        wait(for: [fromCacheExpectation], timeout: timeout)
+    }
+
+    func testFromCacheIsSetToFalseForAResourceFetchedOnline() {
+        ensureDatabaseExists()
+        let fromCacheExpectation = self.expectation(description: "fromCache should be set to false for a resource fetched online")
+
+        reachabilityManager.networkReachabilityStatus = .reachable(.ethernetOrWiFi)
+
+        AzureData.get(databaseWithId: databaseId) { r in
+            XCTAssertTrue(r.result.isSuccess)
+            XCTAssertFalse(r.fromCache)
+
+            self.purgeCache()
+
+            fromCacheExpectation.fulfill()
+        }
+
+        wait(for: [fromCacheExpectation], timeout: timeout)
+    }
+
+    func testDatabasesAreCachedLocallyWhenNetworkIsReachable() {
+        ensureDatabaseExists()
+        ensureResourcesAreCachedLocallyWhenNetworkIsReachable(
+            resourceType: Database.self,
+            getResources: { AzureData.databases(callback: $0) },
+            localCachePath: "dbs/"
+        )
+    }
+
+    func testDatabasesAreFetchedFromLocalCacheWhenNetworkIsNotReachable() {
+        ensureDatabaseExists()
+        ensureResourcesAreFetchedFromLocalCacheWhenNetworkIsNotReachable(
+            resourceType: Database.self,
+            getResources: { AzureData.databases(callback: $0) }
+        )
+    }
+
+    func testCollectionsAreCachedLocallyWhenNetworkIsReachable() {
+        ensureCollectionExists()
+        let mainExpectation = expectation(description: "collections should be cached locally when the network is reachable")
+
+        AzureData.get(databaseWithId: databaseId) { r in
+            XCTAssertNotNil(r.resource!)
+
+            let database = r.resource!
+
+            self.ensureResourcesAreCachedLocallyWhenNetworkIsReachable(
+                resourceType: DocumentCollection.self,
+                getResources: { AzureData.get(collectionsIn: database, callback: $0) },
+                localCachePath: "dbs/\(database.resourceId)/colls/",
+                completion: { mainExpectation.fulfill() }
+            )
+        }
+
+        wait(for: [mainExpectation], timeout: timeout)
+    }
+
+    func testCollectionsAreFetchedFromLocalCacheWhenNetworkIsNotReachable() {
+        ensureCollectionExists()
+        let mainExpectation = self.expectation(description: "collections should be fetched from the local cache when the network is not reachable")
+
+        AzureData.get(databaseWithId: databaseId) { r in
+            XCTAssertNotNil(r.resource)
+
+            let database = r.resource!
+
+            self.ensureResourcesAreFetchedFromLocalCacheWhenNetworkIsNotReachable(
+                resourceType: DocumentCollection.self,
+                getResources: { AzureData.get(collectionsIn: database, callback: $0) },
+                completion: { mainExpectation.fulfill() }
+            )
+        }
+
+        wait(for: [mainExpectation], timeout: timeout)
+    }
+
+    func testDocumentsAreCachedLocallyWhenNetworkIsReachable() {
+        ensureDocumentExists()
+        let mainExpectation = self.expectation(description: "documents should be cached locally when the network is reachable")
+
+        AzureData.get(collectionWithId: self.collectionId, inDatabase: self.databaseId) { r in
+            XCTAssertNotNil(r.resource)
+
+            let collection = r.resource!
+
+            self.ensureResourcesAreCachedLocallyWhenNetworkIsReachable(
+                resourceType: Document.self,
+                getResources: { AzureData.get(documentsAs: Document.self, in: collection, callback: $0) },
+                localCachePath: "\(collection.selfLink!)docs/)",
+                completion: { mainExpectation.fulfill() }
+            )
+        }
+
+        wait(for: [mainExpectation], timeout: timeout)
+    }
+
+    func testDocumentsAreFetchedFromLocalCacheWhenNetworkIsNotReachable() {
+        ensureDocumentExists()
+        let mainExpectation = self.expectation(description: "documents should be fetched from the local cache when the network is not reachable")
+
+        AzureData.get(collectionWithId: self.collectionId, inDatabase: self.databaseId) { r in
+            XCTAssertNotNil(r.resource)
+
+            let collection = r.resource!
+
+            self.ensureResourcesAreFetchedFromLocalCacheWhenNetworkIsNotReachable(
+                resourceType: Document.self,
+                getResources: { AzureData.get(documentsAs: Document.self, in: collection, callback: $0) },
+                completion: { mainExpectation.fulfill() }
+            )
+        }
+
+        wait(for: [mainExpectation], timeout: timeout)
+    }
+
+    func testThatDeletingAResourceRemotelyAlsoDeletesItFromTheCache() {
+        let deleteFromCacheExpectation = self.expectation(description: "a resource deleted remotely should also be deleted from the cache")
+
+        ensureDatabaseExists { database in
+            AzureData.delete(databaseWithId: database.id) { r in
+                XCTAssertTrue(r.result.isSuccess)
+
+                self.waitForCacheToProcessResources {
+                    let databasesCachesDirectoryURL = URL(string: "dbs/", relativeTo: self.cachesDirectoryURL)
+                    let directoryURL = URL(string: "\(database.resourceId)/", relativeTo: databasesCachesDirectoryURL)!
+                    let JSONFileURL = URL(string: "\(database.resourceId).json", relativeTo: directoryURL)!
+
+
+                    XCTAssertFalse(FileManager.default.fileExists(atPath: directoryURL.path))
+                    XCTAssertFalse(FileManager.default.fileExists(atPath: JSONFileURL.path))
+
+                    deleteFromCacheExpectation.fulfill()
+                }
+            }
+        }
+
+        wait(for: [deleteFromCacheExpectation], timeout: timeout)
+    }
+
+    func testThatResourcesAreDeletedFromTheCacheIfTheRemoteReturns404() {
+        let deleteExpectation = self.expectation(description: "a resource should be deleted from the cache if the remote database returns 404 for it")
+
+        ensureDatabaseExists { database in
+            AzureData.delete(databaseWithId: database.id) { r in
+                XCTAssertTrue(r.result.isSuccess)
+
+                AzureData.get(databaseWithId: database.id) { r in
+                    XCTAssertFalse(r.result.isSuccess)
+                    XCTAssertTrue(r.clientError.isNotFoundError)
+
+                    self.waitForCacheToProcessResources {
+                        let databasesCachesDirectoryURL = URL(string: "dbs/", relativeTo: self.cachesDirectoryURL)
+                        let directoryURL = URL(string: "\(database.resourceId)/", relativeTo: databasesCachesDirectoryURL)!
+                        let JSONFileURL = URL(string: "\(database.resourceId).json", relativeTo: directoryURL)!
+
+                        XCTAssertFalse(FileManager.default.fileExists(atPath: directoryURL.path))
+                        XCTAssertFalse(FileManager.default.fileExists(atPath: JSONFileURL.path))
+
+                        deleteExpectation.fulfill()
+                    }
+                }
+            }
+        }
+
+        wait(for: [deleteExpectation], timeout: timeout)
+    }
+
+    // MARK: - Private helpers
+
+    private func ensureResourcesAreCachedLocallyWhenNetworkIsReachable<T: CodableResource>(
+        resourceType: T.Type,
+        getResources: @escaping (_ completion: @escaping (Response<Resources<T>>) -> ()) -> (),
+        localCachePath: String,
+        completion: (() -> ())? = nil
+    ) {
+        var resources = [T]()
+
+        queue.async {
+            getResources { r in
+                XCTAssertTrue(r.result.isSuccess)
+                resources = r.resource?.items ?? []
+
+                self.waitForCacheToProcessResources {
+                    self.listExpectation.fulfill()
+                }
+            }
+        }
+
+        DispatchQueue.main.async {
+            self.wait(for: [self.listExpectation], timeout: self.timeout)
+
+            XCTAssertFalse(resources.isEmpty)
+
+            let resourcesCacheDirectoryURL = URL(string: localCachePath, relativeTo: self.cachesDirectoryURL)!
+
+            resources.forEach { resource in
+                let directoryURL = URL(string: "\(resource.resourceId)/", relativeTo: resourcesCacheDirectoryURL)!
+                let JSONFileURL = URL(string: "\(resource.resourceId).json", relativeTo: directoryURL)!
+                XCTAssertTrue(FileManager.default.fileExists(atPath: directoryURL.path))
+                XCTAssertTrue(FileManager.default.fileExists(atPath: JSONFileURL.path))
+            }
+
+            self.purgeCache()
+
+            completion?()
+        }
+    }
+
+    private func ensureResourcesAreFetchedFromLocalCacheWhenNetworkIsNotReachable<T: CodableResource>(
+        resourceType: T.Type,
+        getResources: @escaping (_ completion: @escaping (Response<Resources<T>>) -> ()) -> (),
+        completion: (() -> ())? = nil
+    ) {
+        var onlineResources = [T]()
+        var offlineResources = [T]()
+
+        queue.async {
+            getResources { r in
+                onlineResources = r.resource?.items ?? []
+
+                self.waitForCacheToProcessResources {
+                    self.reachabilityManager.networkReachabilityStatus = .notReachable
+
+                    getResources { r in
+                        offlineResources = r.resource?.items ?? []
+                        self.listExpectation.fulfill()
+                    }
+                }
+            }
+        }
+
+        DispatchQueue.main.async {
+            self.wait(for: [self.listExpectation], timeout: self.timeout)
+
+            XCTAssertFalse(onlineResources.isEmpty)
+            XCTAssertFalse(offlineResources.isEmpty)
+
+            offlineResources.forEach { resource in
+                XCTAssertTrue(onlineResources.contains(where: { $0.resourceId == resource.resourceId }))
+            }
+
+            self.purgeCache()
+
+            completion?()
+        }
+    }
+
+    private func waitForCacheToProcessResources(_ completion: @escaping () -> Void) {
+        queue.asyncAfter(deadline: .now() + self.cacheOperationDuration) {
+            completion()
+        }
+    }
+
+    private func purgeCache() {
+        try! ResourceCache.purge()
+    }
+}
+
+// MARK: -
+
+class MockReachabilityManager: ReachabilityManagerType {
+    var networkReachabilityStatus: NetworkReachabilityStatus = .reachable(.ethernetOrWiFi) {
+        didSet {
+            if isListening { listener?(networkReachabilityStatus) }
+        }
+    }
+
+    var listener: ReachabilityStatusListener?
+    var isListening = false
+
+    init(_ status: NetworkReachabilityStatus) {
+        self.networkReachabilityStatus = status
+    }
+
+    func registerListener(_ listener: @escaping ReachabilityStatusListener) {
+        self.listener = listener
+    }
+
+    func startListening() -> Bool {
+        isListening = true
+        listener?(networkReachabilityStatus)
+        return true
+    }
+
+    func stopListening() {
+        isListening = false
+    }
+}
+
+#endif

--- a/AzureData/Tests/_AzureDataTests.swift
+++ b/AzureData/Tests/_AzureDataTests.swift
@@ -1,0 +1,107 @@
+//
+//  _AzureDataTests.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import XCTest
+@testable import AzureData
+
+class _AzureDataTests: XCTestCase {
+
+    let timeout: TimeInterval = 30.0
+
+    var resourceName: String?
+    var resourceType: ResourceType!
+
+    var rname: String { return resourceName ?? resourceType.name }
+
+    var databaseId:     String { return "\(rname)TestsDatabase" }
+    var collectionId:   String { return "\(rname)TestsCollection" }
+    var documentId:     String { return "\(rname)TestsDocument" }
+    var userId:         String { return "\(rname)TestsUser" }
+    var resourceId:     String { return "\(rname)Tests\(rname)" }
+    var replacedId:     String { return "\(rname)Replaced" }
+
+    lazy var createExpectation   = self.expectation(description: "should create and return \(rname)")
+    lazy var listExpectation     = self.expectation(description: "should return a list of \(rname)")
+    lazy var getExpectation      = self.expectation(description: "should get and return \(rname)")
+    lazy var deleteExpectation   = self.expectation(description: "should delete \(rname)")
+    lazy var queryExpectation    = self.expectation(description: "should query \(rname)")
+    lazy var replaceExpectation  = self.expectation(description: "should replace \(rname)")
+    lazy var replaceExpectation2 = self.expectation(description: "should replace \(rname)")
+    lazy var refreshExpectation  = self.expectation(description: "should refresh \(rname)")
+    lazy var executeExpectation  = self.expectation(description: "should execute \(rname)")
+
+    override func setUp() {
+        super.setUp()
+
+        // AzureData.configure(forAccountNamed: "<Database Name>", withMasterKey: "<Database Master Key OR Resource Permission Token>", withPermissionMode: "<Master Key Permission Mode>")
+        AzureData.offlineDataEnabled = true
+    }
+
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func ensureDatabaseExists(completion: ((Database) -> ())? = nil) {
+        ensureResourceExists(
+            type: Database.self,
+            get: { AzureData.get(databaseWithId: self.databaseId, callback: $0) },
+            create: { AzureData.create(databaseWithId: self.databaseId, callback: $0) },
+            completion: completion
+        )
+    }
+
+    func ensureCollectionExists(completion: ((DocumentCollection) -> ())? = nil) {
+        ensureDatabaseExists()
+        ensureResourceExists(
+            type: DocumentCollection.self,
+            get: { AzureData.get(collectionWithId: self.collectionId, inDatabase: self.databaseId, callback: $0) },
+            create: { AzureData.create(collectionWithId: self.collectionId, inDatabase: self.databaseId, callback: $0) },
+            completion: completion
+        )
+    }
+
+    func ensureDocumentExists(completion: ((Document) -> ())? = nil) {
+        ensureCollectionExists()
+        ensureResourceExists(
+            type: Document.self,
+            get: { AzureData.get(documentWithId: self.documentId, as: Document.self, inCollection: self.collectionId, inDatabase: self.databaseId, callback: $0) },
+            create: { AzureData.create(Document(self.documentId), inCollection: self.collectionId, inDatabase: self.databaseId, callback: $0) },
+            completion: completion
+        )
+    }
+
+    // MARK: - Private helpers
+
+    private func ensureResourceExists<T: CodableResource>(
+        type: T.Type,
+        get: @escaping (_ completion: @escaping (Response<T>) -> ()) -> (),
+        create: @escaping (_ completion: @escaping (Response<T>) -> ()) -> (),
+        completion: ((T) -> ())? = nil
+    ) {
+        let ensureExpectation = expectation(description: "\(String(describing: type).lowercased()) should exist")
+        var resource: T? = nil
+
+        func setResource(from response: Response<T>) {
+            resource = response.resource
+            ensureExpectation.fulfill()
+        }
+
+        get { r in
+            if r.result.isSuccess { setResource(from: r) ; return }
+            create { r in setResource(from: r) }
+        }
+
+        wait(for: [ensureExpectation], timeout: timeout)
+
+        precondition(resource != nil, "\(String(describing: type).lowercased()) should exist")
+
+        completion?(resource!)
+    }
+}
+


### PR DESCRIPTION
Fixes #69 and #71.

Changes Proposed in this pull request:
- Fix the issue preventing some cached resources from being loaded when the network is not reachable
- Delete a resource from the cache if the remote database returns `404`
- Refactor `ReachabilityManager` to make it testable
- Add tests for the offline capabilities
