### PR TITLE
Offline Write

### DIFF
--- a/AzureData/AzureData.xcodeproj/project.pbxproj
+++ b/AzureData/AzureData.xcodeproj/project.pbxproj
@@ -29,16 +29,37 @@
 		32532A5C207825A1002BFFCA /* ResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32532A59207825A1002BFFCA /* ResponseMetadata.swift */; };
 		32532A5E207825A1002BFFCA /* ResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32532A59207825A1002BFFCA /* ResponseMetadata.swift */; };
 		32532A60207825A1002BFFCA /* ResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32532A59207825A1002BFFCA /* ResponseMetadata.swift */; };
-		3276EA13208F3450003F6382 /* OfflineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3276EA12208F3450003F6382 /* OfflineTests.swift */; };
-		3276EA14208F3450003F6382 /* OfflineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3276EA12208F3450003F6382 /* OfflineTests.swift */; };
-		3276EA15208F3450003F6382 /* OfflineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3276EA12208F3450003F6382 /* OfflineTests.swift */; };
+		3276EA13208F3450003F6382 /* OfflineReadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3276EA12208F3450003F6382 /* OfflineReadTests.swift */; };
+		3276EA14208F3450003F6382 /* OfflineReadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3276EA12208F3450003F6382 /* OfflineReadTests.swift */; };
+		3276EA15208F3450003F6382 /* OfflineReadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3276EA12208F3450003F6382 /* OfflineReadTests.swift */; };
+		327996FF209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327996FE209C830C0062A374 /* ResourceWriteOperationQueue.swift */; };
+		32799700209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327996FE209C830C0062A374 /* ResourceWriteOperationQueue.swift */; };
+		32799701209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327996FE209C830C0062A374 /* ResourceWriteOperationQueue.swift */; };
+		32799702209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327996FE209C830C0062A374 /* ResourceWriteOperationQueue.swift */; };
+		329AA646209CEF470007A955 /* ResourceSystemProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329AA645209CEF470007A955 /* ResourceSystemProperties.swift */; };
+		329AA647209CEF470007A955 /* ResourceSystemProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329AA645209CEF470007A955 /* ResourceSystemProperties.swift */; };
+		329AA648209CEF470007A955 /* ResourceSystemProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329AA645209CEF470007A955 /* ResourceSystemProperties.swift */; };
+		329AA649209CEF470007A955 /* ResourceSystemProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329AA645209CEF470007A955 /* ResourceSystemProperties.swift */; };
 		32A5030720A1D16F000C5948 /* ResourceEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A5030620A1D16F000C5948 /* ResourceEncryptor.swift */; };
 		32A5030820A1D16F000C5948 /* ResourceEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A5030620A1D16F000C5948 /* ResourceEncryptor.swift */; };
 		32A5030920A1D16F000C5948 /* ResourceEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A5030620A1D16F000C5948 /* ResourceEncryptor.swift */; };
 		32A5030A20A1D16F000C5948 /* ResourceEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A5030620A1D16F000C5948 /* ResourceEncryptor.swift */; };
+		32AABD1E20AC9FB900F66DC6 /* OfflineWriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AABD1D20AC9FB900F66DC6 /* OfflineWriteTests.swift */; };
+		32AABD1F20AC9FB900F66DC6 /* OfflineWriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AABD1D20AC9FB900F66DC6 /* OfflineWriteTests.swift */; };
+		32AABD2020AC9FB900F66DC6 /* OfflineWriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AABD1D20AC9FB900F66DC6 /* OfflineWriteTests.swift */; };
+		32AABD2220ACA05400F66DC6 /* MockReachabilityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AABD2120ACA05400F66DC6 /* MockReachabilityManager.swift */; };
+		32AABD2320ACA05400F66DC6 /* MockReachabilityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AABD2120ACA05400F66DC6 /* MockReachabilityManager.swift */; };
+		32AABD2420ACA05400F66DC6 /* MockReachabilityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AABD2120ACA05400F66DC6 /* MockReachabilityManager.swift */; };
+		32AABD2720ACA83300F66DC6 /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AABD2620ACA83300F66DC6 /* MockURLSession.swift */; };
+		32AABD2820ACA83300F66DC6 /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AABD2620ACA83300F66DC6 /* MockURLSession.swift */; };
+		32AABD2920ACA83300F66DC6 /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AABD2620ACA83300F66DC6 /* MockURLSession.swift */; };
 		32AD4619207976AB00A0D02F /* ResponseMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */; };
 		32AD461A207976AB00A0D02F /* ResponseMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */; };
 		32AD461B207976AB00A0D02F /* ResponseMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */; };
+		32EB2C1D209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
+		32EB2C1E209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
+		32EB2C1F209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
+		32EB2C20209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
 		9302CE412059A3A5000F6885 /* AzureCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9302CE422059A3A5000F6885 /* AzureCore.framework */; };
 		9302CE432059A3C5000F6885 /* AzureCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9302CE442059A3C5000F6885 /* AzureCore.framework */; };
 		9302CE452059A3D2000F6885 /* AzureCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9302CE462059A3D2000F6885 /* AzureCore.framework */; };
@@ -307,9 +328,15 @@
 		323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportsPermissionToken.swift; sourceTree = "<group>"; };
 		323B71A9207E6B75000F20F6 /* ResourceRequestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceRequestError.swift; sourceTree = "<group>"; };
 		32532A59207825A1002BFFCA /* ResponseMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseMetadata.swift; sourceTree = "<group>"; };
-		3276EA12208F3450003F6382 /* OfflineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineTests.swift; sourceTree = "<group>"; };
+		3276EA12208F3450003F6382 /* OfflineReadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineReadTests.swift; sourceTree = "<group>"; };
+		327996FE209C830C0062A374 /* ResourceWriteOperationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceWriteOperationQueue.swift; sourceTree = "<group>"; };
+		329AA645209CEF470007A955 /* ResourceSystemProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceSystemProperties.swift; sourceTree = "<group>"; };
 		32A5030620A1D16F000C5948 /* ResourceEncryptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceEncryptor.swift; sourceTree = "<group>"; };
+		32AABD1D20AC9FB900F66DC6 /* OfflineWriteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineWriteTests.swift; sourceTree = "<group>"; };
+		32AABD2120ACA05400F66DC6 /* MockReachabilityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockReachabilityManager.swift; sourceTree = "<group>"; };
+		32AABD2620ACA83300F66DC6 /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
 		32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseMetadataTests.swift; sourceTree = "<group>"; };
+		32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceWriteOperation.swift; sourceTree = "<group>"; };
 		9302CE422059A3A5000F6885 /* AzureCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AzureCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9302CE442059A3C5000F6885 /* AzureCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AzureCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9302CE462059A3D2000F6885 /* AzureCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AzureCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -447,6 +474,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		32AABD2520ACA81D00F66DC6 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				32AABD2120ACA05400F66DC6 /* MockReachabilityManager.swift */,
+				32AABD2620ACA83300F66DC6 /* MockURLSession.swift */,
+			);
+			name = Mocks;
+			sourceTree = "<group>";
+		};
 		B52240181FB33CD000D0343F /* Source */ = {
 			isa = PBXGroup;
 			children = (
@@ -468,6 +504,8 @@
 				9317A81620656ED100338B63 /* ResourceOracle.swift */,
 				9319DF012069DD7B0083475D /* ResourceTokenProvider.swift */,
 				B522401D1FB33CD000D0343F /* ResourceType.swift */,
+				32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */,
+				327996FE209C830C0062A374 /* ResourceWriteOperationQueue.swift */,
 				B58361991FB779B6001CEC66 /* Response.swift */,
 				323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */,
 				B52240381FB33CD000D0343F /* UtilityExtensions.swift */,
@@ -547,9 +585,11 @@
 		B55AEFE81FB34D6500F7BEED /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				3276EA12208F3450003F6382 /* OfflineReadTests.swift */,
+				32AABD1D20AC9FB900F66DC6 /* OfflineWriteTests.swift */,
 				B522403D1FB33D1200D0343F /* QueryTests.swift */,
 				32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */,
-				3276EA12208F3450003F6382 /* OfflineTests.swift */,
+				32AABD2520ACA81D00F66DC6 /* Mocks */,
 			);
 			name = Domain;
 			sourceTree = "<group>";
@@ -557,7 +597,6 @@
 		B58361B71FBA1339001CEC66 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				B583619C1FB77A70001CEC66 /* Resources.swift */,
 				B58361B81FBA1384001CEC66 /* CodableResource.swift */,
 				323A90E8207F976400537769 /* CodableResources.swift */,
 				B5B6AC281FBA84C400B93106 /* CodableDictionary.swift */,
@@ -570,14 +609,16 @@
 				B58361BD1FBA13A0001CEC66 /* Document.swift */,
 				B58361C21FBA13B0001CEC66 /* DocumentCollection.swift */,
 				B58361D11FBA15A8001CEC66 /* Offer.swift */,
-				32532A59207825A1002BFFCA /* ResponseMetadata.swift */,
 				B58361D61FBA16F9001CEC66 /* Permission.swift */,
 				93935D9A20585C8600F1832A /* PermissionMode.swift */,
+				B583619C1FB77A70001CEC66 /* Resources.swift */,
+				323B71A9207E6B75000F20F6 /* ResourceRequestError.swift */,
+				329AA645209CEF470007A955 /* ResourceSystemProperties.swift */,
+				32532A59207825A1002BFFCA /* ResponseMetadata.swift */,
 				B58361DB1FBA17B5001CEC66 /* StoredProcedure.swift */,
 				B58361E01FBA17C8001CEC66 /* Trigger.swift */,
 				B58361E51FBA17D8001CEC66 /* User.swift */,
 				B58361EA1FBA17E8001CEC66 /* UserDefinedFunction.swift */,
-				323B71A9207E6B75000F20F6 /* ResourceRequestError.swift */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -912,6 +953,7 @@
 			files = (
 				B5B6AC2A1FBA84C400B93106 /* CodableDictionary.swift in Sources */,
 				B507D4F21FBB722000B2D18D /* Conflict.swift in Sources */,
+				329AA647209CEF470007A955 /* ResourceSystemProperties.swift in Sources */,
 				B58361CE1FBA1439001CEC66 /* Attachment.swift in Sources */,
 				9319DEEA20698C3D0083475D /* PermissionProvider.swift in Sources */,
 				9319DEF920698FB90083475D /* PermissionCache.swift in Sources */,
@@ -947,8 +989,10 @@
 				9316F450206A977F00D7BA8B /* ResourceLocation.swift in Sources */,
 				932F01342076AC5A001D708B /* ResourceCache.swift in Sources */,
 				9319DEEF20698C840083475D /* PermissionProviderConfiguration.swift in Sources */,
+				32EB2C1E209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */,
 				B52240961FB3407C00D0343F /* AzureDataExtensions.swift in Sources */,
 				32A5030820A1D16F000C5948 /* ResourceEncryptor.swift in Sources */,
+				32799700209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */,
 				B58361BA1FBA1385001CEC66 /* CodableResource.swift in Sources */,
 				B58361A71FB78F73001CEC66 /* DocumentClient.swift in Sources */,
 				93B7240C2064560F00984CA8 /* MSHttpHeader.swift in Sources */,
@@ -969,11 +1013,13 @@
 				B52240721FB33DF800D0343F /* CollectionTriggerExtensionsTests.swift in Sources */,
 				B52240731FB33DF800D0343F /* UserTests.swift in Sources */,
 				B52240761FB33DF800D0343F /* CollectionDocumentExtensionsTests.swift in Sources */,
+				32AABD1F20AC9FB900F66DC6 /* OfflineWriteTests.swift in Sources */,
 				B522406F1FB33DF800D0343F /* AttachmentTests.swift in Sources */,
 				932832E72072CD9E0075ECC7 /* ExamplePermissionProviderTests.swift in Sources */,
 				B522406E1FB33DF800D0343F /* TriggerTests.swift in Sources */,
 				9317A81D2065763700338B63 /* ResourceOracleTests.swift in Sources */,
-				3276EA14208F3450003F6382 /* OfflineTests.swift in Sources */,
+				3276EA14208F3450003F6382 /* OfflineReadTests.swift in Sources */,
+				32AABD2320ACA05400F66DC6 /* MockReachabilityManager.swift in Sources */,
 				B52240701FB33DF800D0343F /* PermissionTests.swift in Sources */,
 				B52240681FB33DF800D0343F /* StoredProcedureTests.swift in Sources */,
 				B52240771FB33DF800D0343F /* AzureDataTests.swift in Sources */,
@@ -981,6 +1027,7 @@
 				3236FBDE209160F70002FB5F /* _AzureDataTests.swift in Sources */,
 				B52240781FB33DF800D0343F /* DocumentCollectionTests.swift in Sources */,
 				B52240791FB33DF800D0343F /* OfferTests.swift in Sources */,
+				32AABD2820ACA83300F66DC6 /* MockURLSession.swift in Sources */,
 				B522407A1FB33DF800D0343F /* DocumentAttachmentExtensionsTests.swift in Sources */,
 				323A90F320800DEB00537769 /* Extensions.swift in Sources */,
 				B522406C1FB33DF800D0343F /* CollectionUserDefinedFunctionExtensionsTests.swift in Sources */,
@@ -996,6 +1043,7 @@
 			files = (
 				B5B6AC2B1FBA84C400B93106 /* CodableDictionary.swift in Sources */,
 				B507D4F31FBB722000B2D18D /* Conflict.swift in Sources */,
+				329AA648209CEF470007A955 /* ResourceSystemProperties.swift in Sources */,
 				B58361CF1FBA1439001CEC66 /* Attachment.swift in Sources */,
 				9319DEEB20698C3D0083475D /* PermissionProvider.swift in Sources */,
 				9319DEFA20698FB90083475D /* PermissionCache.swift in Sources */,
@@ -1031,8 +1079,10 @@
 				9316F451206A977F00D7BA8B /* ResourceLocation.swift in Sources */,
 				932F01352076AC5A001D708B /* ResourceCache.swift in Sources */,
 				9319DEF020698C840083475D /* PermissionProviderConfiguration.swift in Sources */,
+				32EB2C1F209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */,
 				B52240991FB3407D00D0343F /* AzureDataExtensions.swift in Sources */,
 				32A5030920A1D16F000C5948 /* ResourceEncryptor.swift in Sources */,
+				32799701209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */,
 				B58361BB1FBA1385001CEC66 /* CodableResource.swift in Sources */,
 				B58361A61FB78F73001CEC66 /* DocumentClient.swift in Sources */,
 				93B7240D2064560F00984CA8 /* MSHttpHeader.swift in Sources */,
@@ -1053,11 +1103,13 @@
 				B52240861FB33DFA00D0343F /* CollectionTriggerExtensionsTests.swift in Sources */,
 				B52240871FB33DFA00D0343F /* UserTests.swift in Sources */,
 				B522408A1FB33DFA00D0343F /* CollectionDocumentExtensionsTests.swift in Sources */,
+				32AABD2020AC9FB900F66DC6 /* OfflineWriteTests.swift in Sources */,
 				B52240831FB33DFA00D0343F /* AttachmentTests.swift in Sources */,
 				932832E82072CD9E0075ECC7 /* ExamplePermissionProviderTests.swift in Sources */,
 				B52240821FB33DFA00D0343F /* TriggerTests.swift in Sources */,
 				9317A81E2065763700338B63 /* ResourceOracleTests.swift in Sources */,
-				3276EA15208F3450003F6382 /* OfflineTests.swift in Sources */,
+				3276EA15208F3450003F6382 /* OfflineReadTests.swift in Sources */,
+				32AABD2420ACA05400F66DC6 /* MockReachabilityManager.swift in Sources */,
 				B52240841FB33DFA00D0343F /* PermissionTests.swift in Sources */,
 				B522407C1FB33DFA00D0343F /* StoredProcedureTests.swift in Sources */,
 				B522408B1FB33DFA00D0343F /* AzureDataTests.swift in Sources */,
@@ -1065,6 +1117,7 @@
 				3236FBDF209160F70002FB5F /* _AzureDataTests.swift in Sources */,
 				B522408C1FB33DFA00D0343F /* DocumentCollectionTests.swift in Sources */,
 				B522408D1FB33DFA00D0343F /* OfferTests.swift in Sources */,
+				32AABD2920ACA83300F66DC6 /* MockURLSession.swift in Sources */,
 				B522408E1FB33DFA00D0343F /* DocumentAttachmentExtensionsTests.swift in Sources */,
 				323A90F520800E6C00537769 /* Extensions.swift in Sources */,
 				B52240801FB33DFA00D0343F /* CollectionUserDefinedFunctionExtensionsTests.swift in Sources */,
@@ -1080,6 +1133,7 @@
 			files = (
 				B5B6AC2C1FBA84C400B93106 /* CodableDictionary.swift in Sources */,
 				B507D4F41FBB722000B2D18D /* Conflict.swift in Sources */,
+				329AA649209CEF470007A955 /* ResourceSystemProperties.swift in Sources */,
 				B58361D01FBA1439001CEC66 /* Attachment.swift in Sources */,
 				9319DEEC20698C3D0083475D /* PermissionProvider.swift in Sources */,
 				9319DEFB20698FB90083475D /* PermissionCache.swift in Sources */,
@@ -1115,8 +1169,10 @@
 				9316F452206A977F00D7BA8B /* ResourceLocation.swift in Sources */,
 				932F01362076AC5A001D708B /* ResourceCache.swift in Sources */,
 				9319DEF120698C840083475D /* PermissionProviderConfiguration.swift in Sources */,
+				32EB2C20209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */,
 				B522409C1FB3407E00D0343F /* AzureDataExtensions.swift in Sources */,
 				32A5030A20A1D16F000C5948 /* ResourceEncryptor.swift in Sources */,
+				32799702209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */,
 				B58361BC1FBA1385001CEC66 /* CodableResource.swift in Sources */,
 				B58361A51FB78F71001CEC66 /* DocumentClient.swift in Sources */,
 				93B7240E2064560F00984CA8 /* MSHttpHeader.swift in Sources */,
@@ -1129,6 +1185,7 @@
 			files = (
 				B5B6AC291FBA84C400B93106 /* CodableDictionary.swift in Sources */,
 				B507D4F11FBB722000B2D18D /* Conflict.swift in Sources */,
+				329AA646209CEF470007A955 /* ResourceSystemProperties.swift in Sources */,
 				B58361CD1FBA1439001CEC66 /* Attachment.swift in Sources */,
 				9319DEE920698C3D0083475D /* PermissionProvider.swift in Sources */,
 				9319DEF820698FB90083475D /* PermissionCache.swift in Sources */,
@@ -1164,8 +1221,10 @@
 				9316F44F206A977F00D7BA8B /* ResourceLocation.swift in Sources */,
 				932F01332076AC5A001D708B /* ResourceCache.swift in Sources */,
 				9319DEEE20698C840083475D /* PermissionProviderConfiguration.swift in Sources */,
+				32EB2C1D209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */,
 				B583619F1FB78763001CEC66 /* DocumentClient.swift in Sources */,
 				32A5030720A1D16F000C5948 /* ResourceEncryptor.swift in Sources */,
+				327996FF209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */,
 				B58361B91FBA1385001CEC66 /* CodableResource.swift in Sources */,
 				B52240931FB3407900D0343F /* AzureDataExtensions.swift in Sources */,
 				93B7240B2064560F00984CA8 /* MSHttpHeader.swift in Sources */,
@@ -1186,11 +1245,13 @@
 				B522405E1FB33DF100D0343F /* CollectionTriggerExtensionsTests.swift in Sources */,
 				B522405F1FB33DF100D0343F /* UserTests.swift in Sources */,
 				B52240621FB33DF100D0343F /* CollectionDocumentExtensionsTests.swift in Sources */,
+				32AABD1E20AC9FB900F66DC6 /* OfflineWriteTests.swift in Sources */,
 				B522405B1FB33DF100D0343F /* AttachmentTests.swift in Sources */,
 				932832E62072CD9E0075ECC7 /* ExamplePermissionProviderTests.swift in Sources */,
 				B522405A1FB33DF100D0343F /* TriggerTests.swift in Sources */,
 				9317A81C2065763700338B63 /* ResourceOracleTests.swift in Sources */,
-				3276EA13208F3450003F6382 /* OfflineTests.swift in Sources */,
+				3276EA13208F3450003F6382 /* OfflineReadTests.swift in Sources */,
+				32AABD2220ACA05400F66DC6 /* MockReachabilityManager.swift in Sources */,
 				B522405C1FB33DF100D0343F /* PermissionTests.swift in Sources */,
 				B52240541FB33DF100D0343F /* StoredProcedureTests.swift in Sources */,
 				B52240631FB33DF100D0343F /* AzureDataTests.swift in Sources */,
@@ -1198,6 +1259,7 @@
 				3236FBDD209160F70002FB5F /* _AzureDataTests.swift in Sources */,
 				B52240641FB33DF100D0343F /* DocumentCollectionTests.swift in Sources */,
 				B52240651FB33DF100D0343F /* OfferTests.swift in Sources */,
+				32AABD2720ACA83300F66DC6 /* MockURLSession.swift in Sources */,
 				B52240661FB33DF100D0343F /* DocumentAttachmentExtensionsTests.swift in Sources */,
 				323A90F220800DEB00537769 /* Extensions.swift in Sources */,
 				B52240581FB33DF100D0343F /* CollectionUserDefinedFunctionExtensionsTests.swift in Sources */,

--- a/AzureData/Source/DocumentClientError.swift
+++ b/AzureData/Source/DocumentClientError.swift
@@ -116,7 +116,7 @@ public struct DocumentClientError : Error {
             }
         }
 
-        if let data = data, let errorMessage = try? ErrorMessage.decode(data: data) {
+        if let data = data, let errorMessage = try? JSONDecoder().decode(ErrorMessage.self, from: data) {
             self.resourceError = errorMessage
         }
         
@@ -165,7 +165,7 @@ extension HttpStatusCode {
 
 public extension Optional where Wrapped == DocumentClientError {
     public var isConnectivityError: Bool {
-        return self?.urlError?.code == .notConnectedToInternet //|| urlError?.code == .
+        return self?.baseError?.isConnectivityError ?? false
     }
 }
 
@@ -200,5 +200,11 @@ public extension Response {
         if let errorMessage = clientError?.localizedDescription ?? error?.localizedDescription {
             Log.error(errorMessage)
         }
+    }
+}
+
+extension Error {
+    var isConnectivityError: Bool {
+        return (self as NSError).code == URLError.notConnectedToInternet.rawValue
     }
 }

--- a/AzureData/Source/MSHttpHeader.swift
+++ b/AzureData/Source/MSHttpHeader.swift
@@ -75,15 +75,6 @@ public extension Dictionary where Key == String, Value == String {
     }
 }
 
-extension HTTPURLResponse {
-    var msAltContentPathHeader: String? {
-        return self.allHeaderFields[MSHttpHeader.msAltContentPath.rawValue] as? String
-    }
-
-    var msContinuationHeader: String? {
-        return self.allHeaderFields[MSHttpHeader.msContinuation.rawValue] as? String
-    }
-}
 
 extension URLRequest {
     mutating func addValue(_ value: String, forHTTPHeaderField: MSHttpHeader) {

--- a/AzureData/Source/ResourceOracle.swift
+++ b/AzureData/Source/ResourceOracle.swift
@@ -41,32 +41,36 @@ public class ResourceOracle {
     
     
     // MARK: - storeLinks
-    
-    fileprivate static func _storeLinks(forResource resource: CodableResource) {
-        
-        if let selfLink = resource.selfLink, let altLink = resource.altLink {
-            
-            let altLinkSubstrings  = altLink.split(separator: slashCharacter)
-            let selfLinkSubstrings = selfLink.split(separator: slashCharacter)
-            
-            let count = selfLinkSubstrings.count
-            
-            if count == altLinkSubstrings.count {
-                
-                var i = 0
-                
-                while i < count {
-                    
-                    let altLinkComponent  = altLinkSubstrings.dropLast(i).joined(separator: slashString)
-                    let selfLinkComponent = selfLinkSubstrings.dropLast(i).joined(separator: slashString)
-                    
-                    altLinkLookup[selfLinkComponent] = altLinkComponent
-                    selfLinkLookup[altLinkComponent] = selfLinkComponent
-                    
-                    i += 2
-                }
+
+    static func store(selfLink: String?, forAltLink altLink: String?) {
+        guard let selfLink = selfLink, let altLink = altLink else { return }
+
+        let altLinkSubstrings  = altLink.split(separator: slashCharacter)
+        let selfLinkSubstrings = selfLink.split(separator: slashCharacter)
+
+        let count = selfLinkSubstrings.count
+
+        if count == altLinkSubstrings.count {
+
+            var i = 0
+
+            while i < count {
+
+                let altLinkComponent  = altLinkSubstrings.dropLast(i).joined(separator: slashString)
+                let selfLinkComponent = selfLinkSubstrings.dropLast(i).joined(separator: slashString)
+
+                altLinkLookup[selfLinkComponent] = altLinkComponent
+                selfLinkLookup[altLinkComponent] = selfLinkComponent
+
+                i += 2
             }
         }
+
+        commit()
+    }
+
+    fileprivate static func _storeLinks(forResource resource: CodableResource) {
+        store(selfLink: resource.selfLink, forAltLink: resource.altLink)
     }
     
     public static func storeLinks(forResource resource: CodableResource) {
@@ -107,7 +111,7 @@ public class ResourceOracle {
         _removeLinks(forAltLink: altLink, andSelfLink: selfLinkLookup[altLink])
     }
 
-    fileprivate static func _removeLinks(forResourceWithSelfLink selfLink: String) {
+    static func removeLinks(forResourceWithSelfLink selfLink: String) {
         _removeLinks(forAltLink: altLinkLookup[selfLink], andSelfLink: selfLink)
     }
 

--- a/AzureData/Source/ResourceWriteOperation.swift
+++ b/AzureData/Source/ResourceWriteOperation.swift
@@ -1,0 +1,75 @@
+//
+//  ResourceWriteOperation.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+/// Represents a pending write operation
+/// waiting for an internet connection
+/// to be performed.
+struct ResourceWriteOperation: Codable {
+
+    enum Kind: String, Codable {
+        case create
+        case replace
+        case delete
+    }
+
+    /// The type of operation of the write.
+    let type: Kind
+
+    /// The raw data of the resource to be written.
+    let resource: Data?
+
+    /// The logical location of the resource to be written.
+    let resourceLocation: ResourceLocation
+
+    /// The path (relative to the Azure Data caches directory) on
+    /// the local filesystem of the directory where the resource, its
+    /// children and associated data are stored.
+    let resourceLocalContentPath: String
+
+    /// The HTTP headers necessary to perform
+    /// the write online.
+    let httpHeaders: [String: String]?
+}
+
+// MARK: -
+
+extension ResourceWriteOperation {
+    /// Returns the write operation with the type updated
+    /// to the type provided in parameter.
+    func withType(_ type: Kind) -> ResourceWriteOperation {
+        return ResourceWriteOperation(type: type, resource: self.resource, resourceLocation: self.resourceLocation, resourceLocalContentPath: self.resourceLocalContentPath, httpHeaders: self.httpHeaders)
+    }
+}
+
+// MARK: - Equatable
+
+extension ResourceWriteOperation: Equatable {
+    static func ==(lhs: ResourceWriteOperation, rhs: ResourceWriteOperation) -> Bool {
+        return lhs.hashValue == rhs.hashValue
+    }
+}
+
+// MARK: - Hashable
+
+extension ResourceWriteOperation: Hashable {
+    var hashValue: Int {
+        return resourceLocalContentPath.hashValue
+    }
+}
+
+// MARK: -
+
+extension Array where Element == ResourceWriteOperation {
+    func sortedByResourceType() -> [ResourceWriteOperation] {
+        return self.sorted(by: { lhs, rhs in
+            lhs.resourceLocation.resourceType.isAncestor(of: rhs.resourceLocation.resourceType)
+        })
+    }
+}

--- a/AzureData/Source/ResourceWriteOperationQueue.swift
+++ b/AzureData/Source/ResourceWriteOperationQueue.swift
@@ -1,0 +1,354 @@
+//
+//  ResourceWriteOperationQueue.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import AzureCore
+
+/// Handles the queue of resource write operations
+/// waiting for an internet connection to be performed.
+class ResourceWriteOperationQueue {
+
+    static var shared = ResourceWriteOperationQueue()
+
+    /// The list of pending write operations.
+    private var writes = [ResourceWriteOperation]()
+
+    /// The list of write operations performed online so far.
+    private var processedWrites = [ResourceWriteOperation]()
+
+    /// Whether the queue is currently performing the writes
+    /// online or not.
+    private var isSyncing = false
+
+    private let dispatchQueue = DispatchQueue(label: "com.azure.data.WriteQueue", qos: .background, attributes: [], autoreleaseFrequency: .workItem, target: nil)
+
+    private init() {
+        load()
+    }
+
+    // MARK: - Public API
+
+    /// Enqueues a 'create' or 'replace' operation to be performed
+    /// online when the network becomes reachable.
+    func addCreateOrReplace(resource: Data, location: ResourceLocation, httpHeaders: HttpHeaders? = nil, replacing: Bool = false, callback: @escaping (Response<Data>) -> ()) {
+        createOrReplaceOffline(resource: resource, at: location, replacing: replacing) { [weak self] r in
+            callback(r)
+
+            if r.result.isSuccess {
+                let type: ResourceWriteOperation.Kind = replacing ? .replace : .create
+                self?.enqueue(ResourceWriteOperation(type: type, resource: resource, resourceLocation: location, resourceLocalContentPath: r.msContentPath!, httpHeaders: httpHeaders))
+            }
+        }
+    }
+
+    /// Enqueues a 'delete' operation to be performed online
+    /// when the network becomes reachable.
+    func addDelete(forResourceAt location: ResourceLocation, httpHeaders: HttpHeaders? = nil, callback: @escaping (Response<Data>) -> ()) {
+        deleteOffline(resourceAt: location) { [weak self] r in
+            callback(r)
+
+            if r.result.isSuccess {
+                self?.enqueue(ResourceWriteOperation(type: .delete, resource: nil, resourceLocation: location, resourceLocalContentPath: r.msContentPath!, httpHeaders: httpHeaders))
+            }
+        }
+    }
+
+    /// Performs all the pending write operations online.
+    /// Posts a .OfflineResourceSyncSucceeded notification for each successful write
+    /// and a .OfflineResourceSyncFailed notification for each write that fails.
+    /// Posts a .ResourceWriteOperationQueueProcessed when the all the write
+    /// operations have been successfully processed.
+    func sync() {
+        dispatchQueue.sync { [weak self] in
+            guard let queue = self, !(queue.isSyncing || queue.writes.isEmpty) else { return }
+
+            queue.isSyncing = true
+
+            let writes = queue.writes.sortedByResourceType()
+
+            queue.performWrites(writes) { isSuccess in
+                if isSuccess {
+                    NotificationCenter.default.post(name: .ResourceWriteOperationQueueProcessed, object: nil)
+                }
+
+                queue.removeCachedResources()
+
+                queue.isSyncing = false
+            }
+        }
+    }
+
+    /// Purges the directory on the filesystem storing the pending writes.
+    func purge() {
+        dispatchQueue.sync { [weak self] in
+            do {
+                let urls = try FileManager.default.pendingWritesUrls()
+                try urls.forEach { try FileManager.default.removeItem(at: $0) }
+                self?.writes = []
+
+            } catch {
+                Log.error("❌ Write Queue Error [purge]: " + error.localizedDescription)
+            }
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private func load() {
+        dispatchQueue.async { [weak self] in
+            do {
+                let urls = try FileManager.default.pendingWritesUrls()
+                let data = try urls.map { try Data(contentsOf: $0) }
+                let decoder = JSONDecoder()
+
+                self?.writes = try data.map { try decoder.decode(ResourceWriteOperation.self, from: $0) }
+
+            } catch {
+                Log.error("❌ Write Queue Error [load]: " + error.localizedDescription)
+            }
+        }
+    }
+
+    private func performWrites(_ writes: [ResourceWriteOperation], completion: @escaping (Bool) -> ()) {
+        var writes = writes
+
+        guard !writes.isEmpty else { completion(true) ; return }
+
+        let write = writes.removeFirst()
+
+        performWrite(write) { [weak self] response in
+            guard let queue = self else { completion(false) ; return }
+
+            if !response.fromCache {
+                queue.processedWrites.append(write)
+                queue.postNotification(for: response)
+                queue.removeWrite(write)
+            }
+
+            queue.performWrites(writes, completion: completion)
+        }
+    }
+
+    private func performWrite(_ write: ResourceWriteOperation, callback: @escaping (Response<Data>) -> ()) {
+        switch write.type {
+        case .create, .replace:
+            DocumentClient.shared.createOrReplace(write.resource!, at: write.resourceLocation, replacing: write.type == .replace, additionalHeaders: write.httpHeaders, callback: callback)
+        case .delete:
+            DocumentClient.shared.delete(resourceAt: write.resourceLocation, callback: callback)
+        }
+    }
+
+    private func postNotification(for response: Response<Data>) {
+        switch response.result {
+        case .success(let data):
+            NotificationCenter.default.post(name: .OfflineResourceSyncSucceeded, object: self, userInfo: ["data": data])
+        case .failure(let error):
+            NotificationCenter.default.post(name: .OfflineResourceSyncFailed, object: self, userInfo: ["error": error])
+        }
+    }
+
+    private func removeCachedResources() {
+        while !processedWrites.isEmpty {
+            let path = processedWrites.removeLast().resourceLocalContentPath
+            removeResourceCached(at: path)
+        }
+    }
+
+    private func removeResourceCached(at path: String?) {
+        guard let path = path else { return }
+
+        do {
+            try FileManager.default.removeItem(at: FileManager.default.cacheFileUrl(for: path))
+        } catch {
+            Log.error("❌ Write Queue Error [removeResourceCached]: " + error.localizedDescription)
+        }
+    }
+
+    private func removeWrite(_ write: ResourceWriteOperation) {
+        if let index = writes.index(of: write) {
+            writes.remove(at: index)
+        }
+
+        removeWriteFromDisk(write)
+    }
+
+    private func enqueue(_ write: ResourceWriteOperation) {
+        dispatchQueue.sync {
+            guard let index = writes.index(of: write) else {
+                writes.append(write)
+                persistWriteOnDisk(write)
+                return
+            }
+
+            let existingWrite = writes[index]
+
+            switch (existingWrite.type, write.type) {
+            // If we try to replace a resource previously created,
+            // we should instead create the resource with the new
+            // parameters.
+            case (.create, .replace):
+                writes[index] = write.withType(.create)
+                removeWriteFromDisk(existingWrite)
+                persistWriteOnDisk(write.withType(.create))
+
+            // If we try to delete a previously created resource,
+            // we remove the create operation from the queue
+            // so that nothing is done once we come online.
+            case (.create, .delete):
+                writes.remove(at: index)
+                removeWriteFromDisk(existingWrite)
+
+            // If we try to delete a resource that was previously
+            // updated, we subtitute the replace operation
+            // with the delete one.
+            case (.replace, .delete):
+                writes[index] = write
+                removeWriteFromDisk(existingWrite)
+                persistWriteOnDisk(write)
+
+            // If we try to update a previously updated resource
+            // we replace the old replace operation with the new one.
+            case (.replace, .replace):
+                writes[index] = write
+                removeWriteFromDisk(existingWrite)
+                persistWriteOnDisk(write)
+
+            // If we try to delete a previously delete resource,
+            // we just keep the previous delete in the queue.
+            case (.delete, .delete):
+                break
+
+            // The following cases are conflicts and should
+            // ideally not happen.
+            case (.create, .create),
+                 (.replace, .create),
+                 (.delete, .create),
+                 (.delete, .replace):
+                break
+            }
+        }
+    }
+
+    private func persistWriteOnDisk(_ write: ResourceWriteOperation) {
+        do {
+            try FileManager.default.persistWrite(write)
+
+        } catch {
+            Log.error("❌ Write Queue Error [persistWriteOnDisk]: " + error.localizedDescription)
+        }
+    }
+
+    private func removeWriteFromDisk(_ write: ResourceWriteOperation) {
+        do {
+            try FileManager.default.removeWrite(write)
+
+        } catch {
+            Log.error("❌ Write Queue Error [removeWriteFromDisk]: " + error.localizedDescription)
+        }
+    }
+
+    private func createOrReplaceOffline(resource: Data, at location: ResourceLocation, replacing: Bool = false, callback: @escaping  (Response<Data>) -> ()) {
+        guard let id = resource.id, id.isValidIdForResource else {
+            callback(Response(DocumentClientError(withKind: .invalidId), fromCache: true))
+            return
+        }
+
+        let altLink = location.altLink(forId: id)
+        let knownSelfLink = ResourceOracle.getSelfLink(forAltLink: altLink)
+
+        if replacing && knownSelfLink.isNilOrEmpty {
+            callback(Response(DocumentClientError(withKind: .notFound), fromCache: true))
+            return
+        }
+
+        if !replacing && !knownSelfLink.isNilOrEmpty {
+            callback(Response(DocumentClientError(withKind: .conflict), fromCache: true))
+            return
+        }
+
+        guard let selfLink = knownSelfLink ?? location.selfLink(forResourceId: UUID().uuidString) else {
+            callback(Response(DocumentClientError(withKind: .internalError), fromCache: true))
+            return
+        }
+
+        ResourceCache.cache(resource, usingSelfLink: selfLink, andAltLink: altLink, replacing: replacing)
+
+        let httpResponse = HTTPURLResponse(url: URL(string: selfLink)!, statusCode: replacing ? 200 : 201, httpVersion: nil, headerFields: [
+                MSHttpHeader.msAltContentPath.rawValue: altLink.ancestorPath.valueOrEmpty,
+                MSHttpHeader.msContentPath.rawValue: selfLink
+            ]
+        )!
+
+        callback(Response(request: nil, data: nil, response: httpResponse, result: .success(resource), fromCache: true))
+    }
+
+    private func deleteOffline(resourceAt location: ResourceLocation, callback: @escaping (Response<Data>) -> ()) {
+        guard let selfLink = ResourceOracle.getSelfLink(forAltLink: location.link) else {
+            callback(Response(DocumentClientError(withKind: .notFound), fromCache: true))
+            return
+        }
+
+        ResourceCache.remove(resourceAt: location)
+
+        let httpResponse = HTTPURLResponse(url: URL(string: selfLink)!, statusCode: 204, httpVersion: nil, headerFields: [
+                MSHttpHeader.msAltContentPath.rawValue: location.link.ancestorPath.valueOrEmpty,
+                MSHttpHeader.msContentPath.rawValue: selfLink
+            ]
+        )!
+
+        callback(Response(request: nil, data: nil, response: httpResponse, result: .success(Data()), fromCache: true))
+    }
+}
+
+// MARK: - Notifications
+
+extension Notification.Name {
+    public static let OfflineResourceSyncSucceeded         = Notification.Name("OfflineResourceSyncSucceeded")
+    public static let OfflineResourceSyncFailed            = Notification.Name("OfflineResourceSyncFailed")
+    public static let ResourceWriteOperationQueueProcessed = Notification.Name("OfflineResourceQueueProcessed")
+}
+
+// MARK: - FileManager
+
+extension FileManager {
+    fileprivate static let root = "com.azure.data/writes"
+
+    fileprivate func pendingWritesUrls() throws -> [URL] {
+        let rootUrl = try url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+            .appendingPathComponent(FileManager.root)
+
+        if fileExists(atPath: rootUrl.path) {
+            let contents = try contentsOfDirectory(at: rootUrl, includingPropertiesForKeys: nil, options: .skipsHiddenFiles)
+            return contents
+        }
+
+        return []
+    }
+
+    fileprivate func persistWrite(_ write: ResourceWriteOperation) throws {
+        guard let data = try? JSONEncoder().encode(write) else { return }
+
+        let rootUrl = try url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+            .appendingPathComponent(FileManager.root)
+
+        if !fileExists(atPath: rootUrl.path) {
+            try createDirectory(at: rootUrl, withIntermediateDirectories: true)
+        }
+
+        try data.write(to: rootUrl.appendingPathComponent("\(write.hashValue).json"))
+    }
+
+    fileprivate func removeWrite(_ write: ResourceWriteOperation) throws {
+        let writeUrl = try url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+            .appendingPathComponent(FileManager.root)
+            .appendingPathComponent("\(write.hashValue).json")
+
+        if FileManager.default.fileExists(atPath: writeUrl.path) {
+            try FileManager.default.removeItem(at: writeUrl)
+        }
+    }
+}

--- a/AzureData/Source/ResourceWriteOperationQueue.swift
+++ b/AzureData/Source/ResourceWriteOperationQueue.swift
@@ -105,7 +105,7 @@ class ResourceWriteOperationQueue {
                 let data = try urls.map { try Data(contentsOf: $0) }
                 let decoder = JSONDecoder()
 
-                self?.writes = try data.map { try decoder.decode(ResourceWriteOperation.self, from: $0) }
+                self?.writes = data.compactMap { try? decoder.decode(ResourceWriteOperation.self, from: $0) }
 
             } catch {
                 Log.error("❌ Write Queue Error [load]: " + error.localizedDescription)

--- a/AzureData/Source/Resources/ResourceSystemProperties.swift
+++ b/AzureData/Source/Resources/ResourceSystemProperties.swift
@@ -1,0 +1,66 @@
+//
+//  ResourceSystemProperties.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+/// Used to extract Cosmos DB system properties from
+/// a resource encoded as a `CodableResource` or a `Data` object
+/// without knowing its explicit type.
+struct ResourceSystemProperties: CodableResource {
+    enum CodingKeys: String, CodingKey {
+        case id
+        case resourceId         = "_rid"
+        case selfLink           = "_self"
+        case etag               = "_etag"
+        case timestamp          = "_ts"
+    }
+
+    static var type = ""
+    static var list = ""
+
+    var id:                 String
+    var resourceId: String
+    var selfLink:   String?
+    var etag:               String?
+    var timestamp:          Date?
+    var altLink:            String? = nil
+
+    mutating func setEtag(to tag: String) { etag = tag }
+    mutating func setAltLink(to link: String) { altLink = link }
+
+    init(for resource: CodableResource) {
+        self.id = resource.id
+        self.resourceId = resource.resourceId
+        self.selfLink = resource.selfLink
+        self.etag = resource.etag
+        self.timestamp = resource.timestamp
+        self.altLink = resource.altLink
+    }
+
+    init?(for data: Data) {
+        guard let props = try? JSONDecoder().decode(ResourceSystemProperties.self, from: data) else {
+            return nil
+        }
+
+        self = props
+    }
+}
+
+extension Data {
+    var id: String? {
+        return ResourceSystemProperties(for: self)?.id
+    }
+
+    var selfLink: String? {
+        return ResourceSystemProperties(for: self)?.selfLink
+    }
+
+    var resourceId: String? {
+        return ResourceSystemProperties(for: self)?.resourceId
+    }
+}

--- a/AzureData/Source/Resources/StoredProcedure.swift
+++ b/AzureData/Source/Resources/StoredProcedure.swift
@@ -29,6 +29,7 @@ public struct StoredProcedure : CodableResource, SupportsPermissionToken {
     public mutating func setAltLink(to link: String) {
         self.altLink = link
     }
+
     public mutating func setEtag(to tag: String) {
         self.etag = tag
     }

--- a/AzureData/Source/UtilityExtensions.swift
+++ b/AzureData/Source/UtilityExtensions.swift
@@ -23,7 +23,6 @@ extension Optional where Wrapped == String {
     }
 }
 
-
 extension Optional where Wrapped == Date {
     
     var valueOrEmpty: String {
@@ -34,23 +33,6 @@ extension Optional where Wrapped == Date {
         return self != nil ? "\(self!.timeIntervalSince1970)" : "nil"
     }
 }
-
-extension Decodable {
-    static func decode(data: Data) throws -> Self {
-        let decoder = JSONDecoder()
-        return try decoder.decode(Self.self, from: data)
-    }
-}
-
-
-extension Encodable {
-    func encode() throws -> Data {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .prettyPrinted
-        return try encoder.encode(self)
-    }
-}
-
 
 extension DecodingError {
     
@@ -65,5 +47,35 @@ extension DecodingError {
         case .valueNotFound(let type, let context):
             return "decodeError: valueNotFound\n\ttype: \(type)\n\tcontext: \(context)\n"
         }
+    }
+}
+
+extension String {
+    /// "dbs/TC1AAA==/colls/TC1AAMDvwgA=".path = ("dbs/TC1AAA==/colls", "TC1AAMDvwgA=")
+    var path: (directory: String, file: String)? {
+        let components = self.split(separator: "/")
+        let count = components.count
+
+        guard count > 0 else { return nil }
+        guard count >= 2 else { return ("/", String(components[count - 1])) }
+
+        return (components[0...(count - 2)].joined(separator: "/"), String(components[count - 1]))
+    }
+
+    /// "dbs/TC1AAA==/colls/TC1AAMDvwgA=".contentPath = "dbs/TC1AAA=="
+    /// "dbs/TC1AAA==/colls/TC1AAMDvwgA=/docs/ZBcw7B==".contentPath = "dbs/TC1AAA==/colls/TC1AAMDvwgA="
+    var ancestorPath: String? {
+        let components = self.split(separator: "/")
+        let count = components.count
+
+        guard count > 2 else { return nil }
+
+        return components[0...(count - 3)].joined(separator: "/")
+    }
+
+    /// "dbs/TC1AAA==/colls/TC1AAMDvwgA=".lastPathComponent = "TC1AAMDvwgA="
+    var lastPathComponent: String {
+        let components = self.split(separator: "/")
+        return components.count > 1 ? String(components[components.count - 1]) : self
     }
 }

--- a/AzureData/Tests/Extensions.swift
+++ b/AzureData/Tests/Extensions.swift
@@ -26,6 +26,14 @@ extension Optional where Wrapped == DocumentClientError {
         return true
     }
 
+    var isConflictError: Bool {
+        guard let errorKind = self?.kind, case .conflict = errorKind else {
+            return false
+        }
+
+        return true
+    }
+
     func isInvalidHeaderError(forHeader header: MSHttpHeader, withMessage message: String) -> Bool {
         guard let errorKind = self?.kind else { return false }
 

--- a/AzureData/Tests/MockReachabilityManager.swift
+++ b/AzureData/Tests/MockReachabilityManager.swift
@@ -1,0 +1,39 @@
+//
+//  MockReachabilityManager.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+import AzureCore
+
+class MockReachabilityManager: ReachabilityManagerType {
+    var networkReachabilityStatus: NetworkReachabilityStatus = .reachable(.ethernetOrWiFi) {
+        didSet {
+            if isListening { listener?(networkReachabilityStatus) }
+        }
+    }
+
+    var listener: ReachabilityStatusListener?
+    var isListening = false
+
+    init(_ status: NetworkReachabilityStatus) {
+        self.networkReachabilityStatus = status
+    }
+
+    func registerListener(_ listener: @escaping ReachabilityStatusListener) {
+        self.listener = listener
+    }
+
+    func startListening() -> Bool {
+        isListening = true
+        listener?(networkReachabilityStatus)
+        return true
+    }
+
+    func stopListening() {
+        isListening = false
+    }
+}

--- a/AzureData/Tests/MockURLSession.swift
+++ b/AzureData/Tests/MockURLSession.swift
@@ -1,0 +1,47 @@
+//
+//  MockURLSession.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+class MockURLSession: URLSession {
+
+    private var response: URLResponse?
+    private var data: Data?
+    private var error: Error?
+
+    func shouldReturnResponse(_ response: URLResponse) {
+        self.response = response
+    }
+
+    func shouldReturnData(_ data: Data) {
+        self.data = data
+    }
+
+    func shouldReturnError(_ error: Error) {
+        self.error = error
+    }
+
+    override func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+        return MockURLSessionDataTask { [weak self] in
+            completionHandler(self?.data, self?.response, self?.error)
+        }
+    }
+}
+
+class MockURLSessionDataTask: URLSessionDataTask {
+
+    private let closure: () -> Void
+
+    init(_ closure: @escaping () -> Void) {
+        self.closure = closure
+    }
+
+    override func resume() {
+        closure()
+    }
+}

--- a/AzureData/Tests/OfflineWriteTests.swift
+++ b/AzureData/Tests/OfflineWriteTests.swift
@@ -1,0 +1,152 @@
+//
+//  OfflineWriteTests.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import XCTest
+@testable import AzureCore
+@testable import AzureData
+
+#if !os(watchOS)
+
+class OfflineWriteTests: _AzureDataTests {
+
+    // MARK: -
+
+    override func setUp() {
+        resourceName = "OfflineWrite"
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    func testResourceIsCreatedLocallyWhenTheNetworkIsNotReachable() {
+        turnOffInternetConnection()
+
+        AzureData.create(databaseWithId: databaseId) { r in
+            XCTAssertTrue(r.result.isSuccess)
+            XCTAssertTrue(r.fromCache)
+
+            self.createExpectation.fulfill()
+        }
+
+        wait(for: [createExpectation], timeout: timeout)
+
+        AzureData.databases { r in
+            XCTAssertTrue(r.result.isSuccess)
+            XCTAssertTrue(r.fromCache)
+            XCTAssertNotNil(r.resource)
+            XCTAssertTrue(r.resource!.items.contains(where: { $0.id == self.databaseId }))
+
+            self.purgeCache {
+                self.listExpectation.fulfill()
+            }
+        }
+
+        wait(for: [listExpectation], timeout: timeout)
+    }
+
+    func testConflictIsReturnedWhenTheSameResourceIsCreatedTwiceWhileOffline() {
+        turnOffInternetConnection()
+
+        let conflictExpectation = self.expectation(description: "should return a response with the client error Conflict")
+
+        AzureData.create(databaseWithId: databaseId) { r in
+            XCTAssertTrue(r.result.isSuccess)
+            XCTAssertTrue(r.fromCache)
+
+            self.createExpectation.fulfill()
+        }
+
+        wait(for: [createExpectation], timeout: timeout)
+
+        AzureData.create(databaseWithId: databaseId) { r in
+            XCTAssertTrue(r.result.isFailure)
+            XCTAssertTrue(r.clientError.isConflictError)
+
+            self.purgeCache {
+                conflictExpectation.fulfill()
+            }
+        }
+
+        wait(for: [conflictExpectation], timeout: timeout)
+    }
+
+    func testNotFoundIsReturnedWhenTryingToReplaceANonExistingResourceWhileOffline() {
+        turnOffInternetConnection()
+
+        let notFoundExpectation = self.expectation(description: "should return a response with the client error NotFound")
+
+        ensureCollectionExists { collection in
+            AzureData.replace(Document(self.documentId), in: collection) { r in
+                XCTAssertTrue(r.result.isFailure)
+                XCTAssertTrue(r.clientError.isNotFoundError)
+
+                self.purgeCache {
+                    notFoundExpectation.fulfill()
+                }
+            }
+        }
+
+        wait(for: [notFoundExpectation], timeout: timeout)
+    }
+
+    func testNotFoundIsReturnedWhenTryingToDeleteANonExistingResourceWhileOffline() {
+        turnOffInternetConnection()
+
+        AzureData.delete(databaseWithId: databaseId) { r in
+            XCTAssertTrue(r.result.isFailure)
+            XCTAssertTrue(r.clientError.isNotFoundError)
+
+            self.purgeCache {
+                self.deleteExpectation.fulfill()
+            }
+        }
+
+        wait(for: [deleteExpectation], timeout: timeout)
+    }
+
+    func testPendingWritesArePerformedOnlineOnceTheNetworkIsReachable() {
+        turnOffInternetConnection()
+
+        let onlineCreateExpectation = self.expectation(description: "should create the resource online")
+
+        AzureData.create(databaseWithId: databaseId) { r in
+            XCTAssertTrue(r.result.isSuccess)
+            XCTAssertTrue(r.fromCache)
+
+            self.createExpectation.fulfill()
+        }
+
+        wait(for: [createExpectation], timeout: timeout)
+
+        NotificationCenter.default.addObserver(forName: .OfflineResourceSyncSucceeded, object: nil, queue: nil) { notification in
+            XCTAssertNotNil(notification.userInfo)
+            XCTAssertNotNil(notification.userInfo!["data"] as? Data)
+
+            let database = try? JSONDecoder().decode(Database.self, from: notification.userInfo!["data"] as! Data)
+
+            XCTAssertNotNil(database)
+            XCTAssertEqual(database!.id, self.databaseId)
+            XCTAssertFalse(database!.resourceId.isEmpty)
+
+            self.purgeCache {
+                onlineCreateExpectation.fulfill()
+            }
+        }
+
+        turnOnInternetConnection()
+
+        wait(for: [onlineCreateExpectation], timeout: timeout)
+
+        ensureDatabaseIsDeleted()
+    }
+}
+#endif


### PR DESCRIPTION
Fixes #73.

Changes Proposed in this pull request:
- Queue write operations (create, replace and delete) while offline
- Perform write operations locally while offline
- Automatically push local changes to the remote database as soon as the network becomes reachable
- Notify observers when pending writes are performed online
- Add tests
