### PR TITLE
Ensure Objective-C compatibility

### DIFF
--- a/AzureData/AzureData.xcodeproj/project.pbxproj
+++ b/AzureData/AzureData.xcodeproj/project.pbxproj
@@ -200,6 +200,10 @@
 		32D4D58D20C289B200BF3154 /* ADResourceSystemKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D58B20C289B200BF3154 /* ADResourceSystemKeys.swift */; };
 		32D4D58E20C289B200BF3154 /* ADResourceSystemKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D58B20C289B200BF3154 /* ADResourceSystemKeys.swift */; };
 		32D4D58F20C289B200BF3154 /* ADResourceSystemKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D58B20C289B200BF3154 /* ADResourceSystemKeys.swift */; };
+		32D4D59120C2996900BF3154 /* ADAzureDataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D59020C2996900BF3154 /* ADAzureDataExtensions.swift */; };
+		32D4D59220C2996900BF3154 /* ADAzureDataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D59020C2996900BF3154 /* ADAzureDataExtensions.swift */; };
+		32D4D59320C2996900BF3154 /* ADAzureDataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D59020C2996900BF3154 /* ADAzureDataExtensions.swift */; };
+		32D4D59420C2996900BF3154 /* ADAzureDataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D59020C2996900BF3154 /* ADAzureDataExtensions.swift */; };
 		32EB2C1D209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
 		32EB2C1E209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
 		32EB2C1F209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
@@ -528,6 +532,7 @@
 		32D4D57C20C22B2300BF3154 /* ADConflictStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADConflictStrategy.swift; sourceTree = "<group>"; };
 		32D4D58620C2860F00BF3154 /* ObjectiveCWrappers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCWrappers.swift; sourceTree = "<group>"; };
 		32D4D58B20C289B200BF3154 /* ADResourceSystemKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADResourceSystemKeys.swift; sourceTree = "<group>"; };
+		32D4D59020C2996900BF3154 /* ADAzureDataExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADAzureDataExtensions.swift; sourceTree = "<group>"; };
 		32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceWriteOperation.swift; sourceTree = "<group>"; };
 		32FB702720BD5444009A35D9 /* ADPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADPermission.swift; sourceTree = "<group>"; };
 		32FB703120BD8070009A35D9 /* ADCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADCodable.swift; sourceTree = "<group>"; };
@@ -697,6 +702,7 @@
 			isa = PBXGroup;
 			children = (
 				326E731720BC2041006D2DBD /* ADAzureData.swift */,
+				32D4D59020C2996900BF3154 /* ADAzureDataExtensions.swift */,
 				32D4D57C20C22B2300BF3154 /* ADConflictStrategy.swift */,
 				32D4D57720C2176200BF3154 /* ADDateEncoders.swift */,
 				326E732120BC22EE006D2DBD /* ADPermissionProvider.swift */,
@@ -1261,6 +1267,7 @@
 				B58361B41FB78F7A001CEC66 /* Response.swift in Sources */,
 				B52241021FB3409F00D0343F /* AzureData.swift in Sources */,
 				B52240B21FB3409000D0343F /* ResourceType.swift in Sources */,
+				32D4D59220C2996900BF3154 /* ADAzureDataExtensions.swift in Sources */,
 				3257CCA220C1CCE4004E51FF /* ADDocument.m in Sources */,
 				3257CC5620C1486A004E51FF /* ObjectiveCUtilities.swift in Sources */,
 				9319DEF420698F260083475D /* PermissionProviderError.swift in Sources */,
@@ -1389,6 +1396,7 @@
 				B58361AF1FB78F7A001CEC66 /* Response.swift in Sources */,
 				B52240FD1FB3409E00D0343F /* AzureData.swift in Sources */,
 				B52240C71FB3409100D0343F /* ResourceType.swift in Sources */,
+				32D4D59320C2996900BF3154 /* ADAzureDataExtensions.swift in Sources */,
 				3257CCA320C1CCE4004E51FF /* ADDocument.m in Sources */,
 				3257CC5720C1486A004E51FF /* ObjectiveCUtilities.swift in Sources */,
 				9319DEF520698F260083475D /* PermissionProviderError.swift in Sources */,
@@ -1517,6 +1525,7 @@
 				B58361AA1FB78F78001CEC66 /* Response.swift in Sources */,
 				B52240F81FB3409D00D0343F /* AzureData.swift in Sources */,
 				B52240DC1FB3409200D0343F /* ResourceType.swift in Sources */,
+				32D4D59420C2996900BF3154 /* ADAzureDataExtensions.swift in Sources */,
 				3257CCA420C1CCE4004E51FF /* ADDocument.m in Sources */,
 				3257CC5820C1486A004E51FF /* ObjectiveCUtilities.swift in Sources */,
 				9319DEF620698F260083475D /* PermissionProviderError.swift in Sources */,
@@ -1607,6 +1616,7 @@
 				B583619D1FB77A70001CEC66 /* Resources.swift in Sources */,
 				B52241071FB3409F00D0343F /* AzureData.swift in Sources */,
 				B58361F01FBA19A7001CEC66 /* DatabaseAccount.swift in Sources */,
+				32D4D59120C2996900BF3154 /* ADAzureDataExtensions.swift in Sources */,
 				3257CCA120C1CCE4004E51FF /* ADDocument.m in Sources */,
 				3257CC5520C1486A004E51FF /* ObjectiveCUtilities.swift in Sources */,
 				9319DEF320698F260083475D /* PermissionProviderError.swift in Sources */,

--- a/AzureData/AzureData.xcodeproj/project.pbxproj
+++ b/AzureData/AzureData.xcodeproj/project.pbxproj
@@ -29,9 +29,62 @@
 		32532A5C207825A1002BFFCA /* ResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32532A59207825A1002BFFCA /* ResponseMetadata.swift */; };
 		32532A5E207825A1002BFFCA /* ResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32532A59207825A1002BFFCA /* ResponseMetadata.swift */; };
 		32532A60207825A1002BFFCA /* ResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32532A59207825A1002BFFCA /* ResponseMetadata.swift */; };
-		3276EA13208F3450003F6382 /* OfflineReadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3276EA12208F3450003F6382 /* OfflineReadTests.swift */; };
-		3276EA14208F3450003F6382 /* OfflineReadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3276EA12208F3450003F6382 /* OfflineReadTests.swift */; };
-		3276EA15208F3450003F6382 /* OfflineReadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3276EA12208F3450003F6382 /* OfflineReadTests.swift */; };
+		3257CC5520C1486A004E51FF /* ObjectiveCUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3257CC5420C1486A004E51FF /* ObjectiveCUtilities.swift */; };
+		3257CC5620C1486A004E51FF /* ObjectiveCUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3257CC5420C1486A004E51FF /* ObjectiveCUtilities.swift */; };
+		3257CC5720C1486A004E51FF /* ObjectiveCUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3257CC5420C1486A004E51FF /* ObjectiveCUtilities.swift */; };
+		3257CC5820C1486A004E51FF /* ObjectiveCUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3257CC5420C1486A004E51FF /* ObjectiveCUtilities.swift */; };
+		3257CCA120C1CCE4004E51FF /* ADDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 3257CCA020C1CCE4004E51FF /* ADDocument.m */; };
+		3257CCA220C1CCE4004E51FF /* ADDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 3257CCA020C1CCE4004E51FF /* ADDocument.m */; };
+		3257CCA320C1CCE4004E51FF /* ADDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 3257CCA020C1CCE4004E51FF /* ADDocument.m */; };
+		3257CCA420C1CCE4004E51FF /* ADDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 3257CCA020C1CCE4004E51FF /* ADDocument.m */; };
+		3257CCA620C1D701004E51FF /* ADDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 3257CCA520C1D701004E51FF /* ADDocument.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3257CCA720C1D701004E51FF /* ADDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 3257CCA520C1D701004E51FF /* ADDocument.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3257CCA820C1D701004E51FF /* ADDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 3257CCA520C1D701004E51FF /* ADDocument.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3257CCA920C1D701004E51FF /* ADDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 3257CCA520C1D701004E51FF /* ADDocument.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		326E731820BC2041006D2DBD /* ADAzureData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E731720BC2041006D2DBD /* ADAzureData.swift */; };
+		326E731920BC2041006D2DBD /* ADAzureData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E731720BC2041006D2DBD /* ADAzureData.swift */; };
+		326E731A20BC2041006D2DBD /* ADAzureData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E731720BC2041006D2DBD /* ADAzureData.swift */; };
+		326E731B20BC2041006D2DBD /* ADAzureData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E731720BC2041006D2DBD /* ADAzureData.swift */; };
+		326E731D20BC2185006D2DBD /* ADPermissionMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E731C20BC2185006D2DBD /* ADPermissionMode.swift */; };
+		326E731E20BC2185006D2DBD /* ADPermissionMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E731C20BC2185006D2DBD /* ADPermissionMode.swift */; };
+		326E731F20BC2185006D2DBD /* ADPermissionMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E731C20BC2185006D2DBD /* ADPermissionMode.swift */; };
+		326E732020BC2185006D2DBD /* ADPermissionMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E731C20BC2185006D2DBD /* ADPermissionMode.swift */; };
+		326E732220BC22EE006D2DBD /* ADPermissionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E732120BC22EE006D2DBD /* ADPermissionProvider.swift */; };
+		326E732320BC22EE006D2DBD /* ADPermissionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E732120BC22EE006D2DBD /* ADPermissionProvider.swift */; };
+		326E732420BC22EE006D2DBD /* ADPermissionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E732120BC22EE006D2DBD /* ADPermissionProvider.swift */; };
+		326E732520BC22EE006D2DBD /* ADPermissionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E732120BC22EE006D2DBD /* ADPermissionProvider.swift */; };
+		326E732720BC2339006D2DBD /* ADPermissionProviderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E732620BC2339006D2DBD /* ADPermissionProviderConfiguration.swift */; };
+		326E732820BC2339006D2DBD /* ADPermissionProviderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E732620BC2339006D2DBD /* ADPermissionProviderConfiguration.swift */; };
+		326E732920BC2339006D2DBD /* ADPermissionProviderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E732620BC2339006D2DBD /* ADPermissionProviderConfiguration.swift */; };
+		326E732A20BC2339006D2DBD /* ADPermissionProviderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E732620BC2339006D2DBD /* ADPermissionProviderConfiguration.swift */; };
+		326E732C20BC23BE006D2DBD /* ADResourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E732B20BC23BE006D2DBD /* ADResourceType.swift */; };
+		326E732D20BC23BE006D2DBD /* ADResourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E732B20BC23BE006D2DBD /* ADResourceType.swift */; };
+		326E732E20BC23BE006D2DBD /* ADResourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E732B20BC23BE006D2DBD /* ADResourceType.swift */; };
+		326E732F20BC23BE006D2DBD /* ADResourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E732B20BC23BE006D2DBD /* ADResourceType.swift */; };
+		326E733120BC28B4006D2DBD /* ADResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E733020BC28B4006D2DBD /* ADResponse.swift */; };
+		326E733220BC28B4006D2DBD /* ADResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E733020BC28B4006D2DBD /* ADResponse.swift */; };
+		326E733320BC28B4006D2DBD /* ADResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E733020BC28B4006D2DBD /* ADResponse.swift */; };
+		326E733420BC28B4006D2DBD /* ADResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E733020BC28B4006D2DBD /* ADResponse.swift */; };
+		326E733620BC2AB8006D2DBD /* ADResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E733520BC2AB8006D2DBD /* ADResponseMetadata.swift */; };
+		326E733720BC2AB8006D2DBD /* ADResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E733520BC2AB8006D2DBD /* ADResponseMetadata.swift */; };
+		326E733820BC2AB8006D2DBD /* ADResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E733520BC2AB8006D2DBD /* ADResponseMetadata.swift */; };
+		326E733920BC2AB8006D2DBD /* ADResponseMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E733520BC2AB8006D2DBD /* ADResponseMetadata.swift */; };
+		326E734520BC95E7006D2DBD /* ADDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E734420BC95E7006D2DBD /* ADDatabase.swift */; };
+		326E734620BC95E7006D2DBD /* ADDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E734420BC95E7006D2DBD /* ADDatabase.swift */; };
+		326E734720BC95E7006D2DBD /* ADDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E734420BC95E7006D2DBD /* ADDatabase.swift */; };
+		326E734820BC95E7006D2DBD /* ADDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E734420BC95E7006D2DBD /* ADDatabase.swift */; };
+		326E734A20BC9B9B006D2DBD /* ADResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E734920BC9B9B006D2DBD /* ADResources.swift */; };
+		326E734B20BC9B9B006D2DBD /* ADResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E734920BC9B9B006D2DBD /* ADResources.swift */; };
+		326E734C20BC9B9B006D2DBD /* ADResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E734920BC9B9B006D2DBD /* ADResources.swift */; };
+		326E734D20BC9B9B006D2DBD /* ADResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E734920BC9B9B006D2DBD /* ADResources.swift */; };
+		326E734F20BC9D07006D2DBD /* ObjectiveCBridgeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E734E20BC9D07006D2DBD /* ObjectiveCBridgeable.swift */; };
+		326E735020BC9D07006D2DBD /* ObjectiveCBridgeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E734E20BC9D07006D2DBD /* ObjectiveCBridgeable.swift */; };
+		326E735120BC9D07006D2DBD /* ObjectiveCBridgeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E734E20BC9D07006D2DBD /* ObjectiveCBridgeable.swift */; };
+		326E735220BC9D07006D2DBD /* ObjectiveCBridgeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E734E20BC9D07006D2DBD /* ObjectiveCBridgeable.swift */; };
+		326E735420BCA3FC006D2DBD /* ADDocumentCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E735320BCA3FC006D2DBD /* ADDocumentCollection.swift */; };
+		326E735520BCA3FC006D2DBD /* ADDocumentCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E735320BCA3FC006D2DBD /* ADDocumentCollection.swift */; };
+		326E735620BCA3FC006D2DBD /* ADDocumentCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E735320BCA3FC006D2DBD /* ADDocumentCollection.swift */; };
+		326E735720BCA3FC006D2DBD /* ADDocumentCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E735320BCA3FC006D2DBD /* ADDocumentCollection.swift */; };
 		327996FF209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327996FE209C830C0062A374 /* ResourceWriteOperationQueue.swift */; };
 		32799700209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327996FE209C830C0062A374 /* ResourceWriteOperationQueue.swift */; };
 		32799701209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327996FE209C830C0062A374 /* ResourceWriteOperationQueue.swift */; };
@@ -40,10 +93,85 @@
 		329AA647209CEF470007A955 /* ResourceSystemProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329AA645209CEF470007A955 /* ResourceSystemProperties.swift */; };
 		329AA648209CEF470007A955 /* ResourceSystemProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329AA645209CEF470007A955 /* ResourceSystemProperties.swift */; };
 		329AA649209CEF470007A955 /* ResourceSystemProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329AA645209CEF470007A955 /* ResourceSystemProperties.swift */; };
+		329C7DAF20BEB3EE00A49453 /* ADQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DAE20BEB3EE00A49453 /* ADQuery.swift */; };
+		329C7DB020BEB3EE00A49453 /* ADQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DAE20BEB3EE00A49453 /* ADQuery.swift */; };
+		329C7DB120BEB3EE00A49453 /* ADQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DAE20BEB3EE00A49453 /* ADQuery.swift */; };
+		329C7DB220BEB3EE00A49453 /* ADQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DAE20BEB3EE00A49453 /* ADQuery.swift */; };
+		329C7DB420BEC28000A49453 /* OfflineReadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DB320BEC28000A49453 /* OfflineReadTests.swift */; };
+		329C7DB520BEC28000A49453 /* OfflineReadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DB320BEC28000A49453 /* OfflineReadTests.swift */; };
+		329C7DB620BEC28000A49453 /* OfflineReadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DB320BEC28000A49453 /* OfflineReadTests.swift */; };
+		329C7DB820BECBEB00A49453 /* ADAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DB720BECBEB00A49453 /* ADAttachment.swift */; };
+		329C7DB920BECBEB00A49453 /* ADAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DB720BECBEB00A49453 /* ADAttachment.swift */; };
+		329C7DBA20BECBEB00A49453 /* ADAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DB720BECBEB00A49453 /* ADAttachment.swift */; };
+		329C7DBB20BECBEB00A49453 /* ADAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DB720BECBEB00A49453 /* ADAttachment.swift */; };
+		329C7DBD20BEDCF200A49453 /* ADStoredProcedure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DBC20BEDCF200A49453 /* ADStoredProcedure.swift */; };
+		329C7DBE20BEDCF200A49453 /* ADStoredProcedure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DBC20BEDCF200A49453 /* ADStoredProcedure.swift */; };
+		329C7DBF20BEDCF200A49453 /* ADStoredProcedure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DBC20BEDCF200A49453 /* ADStoredProcedure.swift */; };
+		329C7DC020BEDCF200A49453 /* ADStoredProcedure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DBC20BEDCF200A49453 /* ADStoredProcedure.swift */; };
+		329C7DC220BEE3B500A49453 /* ADUserDefinedFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DC120BEE3B500A49453 /* ADUserDefinedFunction.swift */; };
+		329C7DC320BEE3B500A49453 /* ADUserDefinedFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DC120BEE3B500A49453 /* ADUserDefinedFunction.swift */; };
+		329C7DC420BEE3B500A49453 /* ADUserDefinedFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DC120BEE3B500A49453 /* ADUserDefinedFunction.swift */; };
+		329C7DC520BEE3B500A49453 /* ADUserDefinedFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DC120BEE3B500A49453 /* ADUserDefinedFunction.swift */; };
+		329C7DC720BEE7A600A49453 /* ADTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DC620BEE7A600A49453 /* ADTrigger.swift */; };
+		329C7DC820BEE7A600A49453 /* ADTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DC620BEE7A600A49453 /* ADTrigger.swift */; };
+		329C7DC920BEE7A600A49453 /* ADTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DC620BEE7A600A49453 /* ADTrigger.swift */; };
+		329C7DCA20BEE7A600A49453 /* ADTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DC620BEE7A600A49453 /* ADTrigger.swift */; };
+		329C7DCC20BEF15D00A49453 /* ADUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DCB20BEF15D00A49453 /* ADUser.swift */; };
+		329C7DCD20BEF15D00A49453 /* ADUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DCB20BEF15D00A49453 /* ADUser.swift */; };
+		329C7DCE20BEF15D00A49453 /* ADUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DCB20BEF15D00A49453 /* ADUser.swift */; };
+		329C7DCF20BEF15D00A49453 /* ADUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DCB20BEF15D00A49453 /* ADUser.swift */; };
+		329C7DD120BEF9E100A49453 /* ADResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DD020BEF9E100A49453 /* ADResource.swift */; };
+		329C7DD220BEF9E100A49453 /* ADResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DD020BEF9E100A49453 /* ADResource.swift */; };
+		329C7DD320BEF9E100A49453 /* ADResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DD020BEF9E100A49453 /* ADResource.swift */; };
+		329C7DD420BEF9E100A49453 /* ADResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DD020BEF9E100A49453 /* ADResource.swift */; };
+		329C7DD620BEFDF600A49453 /* ADOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DD520BEFDF600A49453 /* ADOffer.swift */; };
+		329C7DD720BEFDF600A49453 /* ADOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DD520BEFDF600A49453 /* ADOffer.swift */; };
+		329C7DD820BEFDF600A49453 /* ADOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DD520BEFDF600A49453 /* ADOffer.swift */; };
+		329C7DD920BEFDF600A49453 /* ADOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DD520BEFDF600A49453 /* ADOffer.swift */; };
+		329C7DDB20BF08DF00A49453 /* ADSupportsPermissionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DDA20BF08DF00A49453 /* ADSupportsPermissionToken.swift */; };
+		329C7DDC20BF08DF00A49453 /* ADSupportsPermissionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DDA20BF08DF00A49453 /* ADSupportsPermissionToken.swift */; };
+		329C7DDD20BF08DF00A49453 /* ADSupportsPermissionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DDA20BF08DF00A49453 /* ADSupportsPermissionToken.swift */; };
+		329C7DDE20BF08DF00A49453 /* ADSupportsPermissionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DDA20BF08DF00A49453 /* ADSupportsPermissionToken.swift */; };
+		329C7DE020BF0CED00A49453 /* SwiftWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DDF20BF0CED00A49453 /* SwiftWrappers.swift */; };
+		329C7DE120BF0CED00A49453 /* SwiftWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DDF20BF0CED00A49453 /* SwiftWrappers.swift */; };
+		329C7DE220BF0CED00A49453 /* SwiftWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DDF20BF0CED00A49453 /* SwiftWrappers.swift */; };
+		329C7DE320BF0CED00A49453 /* SwiftWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329C7DDF20BF0CED00A49453 /* SwiftWrappers.swift */; };
 		32A5030720A1D16F000C5948 /* ResourceEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A5030620A1D16F000C5948 /* ResourceEncryptor.swift */; };
 		32A5030820A1D16F000C5948 /* ResourceEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A5030620A1D16F000C5948 /* ResourceEncryptor.swift */; };
 		32A5030920A1D16F000C5948 /* ResourceEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A5030620A1D16F000C5948 /* ResourceEncryptor.swift */; };
 		32A5030A20A1D16F000C5948 /* ResourceEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A5030620A1D16F000C5948 /* ResourceEncryptor.swift */; };
+		32A77CD620C0566E00846397 /* ADPartitionKeyDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CD520C0566E00846397 /* ADPartitionKeyDefinition.swift */; };
+		32A77CD720C0566E00846397 /* ADPartitionKeyDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CD520C0566E00846397 /* ADPartitionKeyDefinition.swift */; };
+		32A77CD820C0566E00846397 /* ADPartitionKeyDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CD520C0566E00846397 /* ADPartitionKeyDefinition.swift */; };
+		32A77CD920C0566E00846397 /* ADPartitionKeyDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CD520C0566E00846397 /* ADPartitionKeyDefinition.swift */; };
+		32A77CDB20C0569C00846397 /* ADIndexingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CDA20C0569C00846397 /* ADIndexingMode.swift */; };
+		32A77CDC20C0569C00846397 /* ADIndexingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CDA20C0569C00846397 /* ADIndexingMode.swift */; };
+		32A77CDD20C0569C00846397 /* ADIndexingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CDA20C0569C00846397 /* ADIndexingMode.swift */; };
+		32A77CDE20C0569C00846397 /* ADIndexingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CDA20C0569C00846397 /* ADIndexingMode.swift */; };
+		32A77CE020C056D900846397 /* ADIndexKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CDF20C056D900846397 /* ADIndexKind.swift */; };
+		32A77CE120C056D900846397 /* ADIndexKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CDF20C056D900846397 /* ADIndexKind.swift */; };
+		32A77CE220C056D900846397 /* ADIndexKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CDF20C056D900846397 /* ADIndexKind.swift */; };
+		32A77CE320C056D900846397 /* ADIndexKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CDF20C056D900846397 /* ADIndexKind.swift */; };
+		32A77CE520C056F100846397 /* ADIndexDataType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CE420C056F100846397 /* ADIndexDataType.swift */; };
+		32A77CE620C056F100846397 /* ADIndexDataType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CE420C056F100846397 /* ADIndexDataType.swift */; };
+		32A77CE720C056F100846397 /* ADIndexDataType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CE420C056F100846397 /* ADIndexDataType.swift */; };
+		32A77CE820C056F100846397 /* ADIndexDataType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CE420C056F100846397 /* ADIndexDataType.swift */; };
+		32A77CEA20C0570E00846397 /* ADIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CE920C0570E00846397 /* ADIndex.swift */; };
+		32A77CEB20C0570E00846397 /* ADIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CE920C0570E00846397 /* ADIndex.swift */; };
+		32A77CEC20C0570E00846397 /* ADIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CE920C0570E00846397 /* ADIndex.swift */; };
+		32A77CED20C0570E00846397 /* ADIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CE920C0570E00846397 /* ADIndex.swift */; };
+		32A77CEF20C0573000846397 /* ADIncludedPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CEE20C0573000846397 /* ADIncludedPath.swift */; };
+		32A77CF020C0573000846397 /* ADIncludedPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CEE20C0573000846397 /* ADIncludedPath.swift */; };
+		32A77CF120C0573000846397 /* ADIncludedPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CEE20C0573000846397 /* ADIncludedPath.swift */; };
+		32A77CF220C0573000846397 /* ADIncludedPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CEE20C0573000846397 /* ADIncludedPath.swift */; };
+		32A77CF420C0574A00846397 /* ADExcludedPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CF320C0574A00846397 /* ADExcludedPath.swift */; };
+		32A77CF520C0574A00846397 /* ADExcludedPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CF320C0574A00846397 /* ADExcludedPath.swift */; };
+		32A77CF620C0574A00846397 /* ADExcludedPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CF320C0574A00846397 /* ADExcludedPath.swift */; };
+		32A77CF720C0574A00846397 /* ADExcludedPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CF320C0574A00846397 /* ADExcludedPath.swift */; };
+		32A77CF920C0576600846397 /* ADIndexingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CF820C0576600846397 /* ADIndexingPolicy.swift */; };
+		32A77CFA20C0576600846397 /* ADIndexingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CF820C0576600846397 /* ADIndexingPolicy.swift */; };
+		32A77CFB20C0576600846397 /* ADIndexingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CF820C0576600846397 /* ADIndexingPolicy.swift */; };
+		32A77CFC20C0576600846397 /* ADIndexingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A77CF820C0576600846397 /* ADIndexingPolicy.swift */; };
 		32AABD1E20AC9FB900F66DC6 /* OfflineWriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AABD1D20AC9FB900F66DC6 /* OfflineWriteTests.swift */; };
 		32AABD1F20AC9FB900F66DC6 /* OfflineWriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AABD1D20AC9FB900F66DC6 /* OfflineWriteTests.swift */; };
 		32AABD2020AC9FB900F66DC6 /* OfflineWriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AABD1D20AC9FB900F66DC6 /* OfflineWriteTests.swift */; };
@@ -60,6 +188,18 @@
 		32EB2C1E209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
 		32EB2C1F209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
 		32EB2C20209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
+		32FB702820BD5444009A35D9 /* ADPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FB702720BD5444009A35D9 /* ADPermission.swift */; };
+		32FB702920BD5444009A35D9 /* ADPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FB702720BD5444009A35D9 /* ADPermission.swift */; };
+		32FB702A20BD5444009A35D9 /* ADPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FB702720BD5444009A35D9 /* ADPermission.swift */; };
+		32FB702B20BD5444009A35D9 /* ADPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FB702720BD5444009A35D9 /* ADPermission.swift */; };
+		32FB703220BD8070009A35D9 /* ADCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FB703120BD8070009A35D9 /* ADCodable.swift */; };
+		32FB703320BD8070009A35D9 /* ADCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FB703120BD8070009A35D9 /* ADCodable.swift */; };
+		32FB703420BD8070009A35D9 /* ADCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FB703120BD8070009A35D9 /* ADCodable.swift */; };
+		32FB703520BD8070009A35D9 /* ADCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FB703120BD8070009A35D9 /* ADCodable.swift */; };
+		32FB703720BD9B11009A35D9 /* ADDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FB703620BD9B11009A35D9 /* ADDocument.swift */; };
+		32FB703820BD9B11009A35D9 /* ADDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FB703620BD9B11009A35D9 /* ADDocument.swift */; };
+		32FB703920BD9B11009A35D9 /* ADDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FB703620BD9B11009A35D9 /* ADDocument.swift */; };
+		32FB703A20BD9B11009A35D9 /* ADDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FB703620BD9B11009A35D9 /* ADDocument.swift */; };
 		9302CE412059A3A5000F6885 /* AzureCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9302CE422059A3A5000F6885 /* AzureCore.framework */; };
 		9302CE432059A3C5000F6885 /* AzureCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9302CE442059A3C5000F6885 /* AzureCore.framework */; };
 		9302CE452059A3D2000F6885 /* AzureCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9302CE462059A3D2000F6885 /* AzureCore.framework */; };
@@ -328,15 +468,50 @@
 		323AE9492080230E00EAE1F5 /* SupportsPermissionToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportsPermissionToken.swift; sourceTree = "<group>"; };
 		323B71A9207E6B75000F20F6 /* ResourceRequestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceRequestError.swift; sourceTree = "<group>"; };
 		32532A59207825A1002BFFCA /* ResponseMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseMetadata.swift; sourceTree = "<group>"; };
-		3276EA12208F3450003F6382 /* OfflineReadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineReadTests.swift; sourceTree = "<group>"; };
+		3257CC5420C1486A004E51FF /* ObjectiveCUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCUtilities.swift; sourceTree = "<group>"; };
+		3257CCA020C1CCE4004E51FF /* ADDocument.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ADDocument.m; sourceTree = "<group>"; };
+		3257CCA520C1D701004E51FF /* ADDocument.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADDocument.h; sourceTree = "<group>"; };
+		326E731720BC2041006D2DBD /* ADAzureData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADAzureData.swift; sourceTree = "<group>"; };
+		326E731C20BC2185006D2DBD /* ADPermissionMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADPermissionMode.swift; sourceTree = "<group>"; };
+		326E732120BC22EE006D2DBD /* ADPermissionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADPermissionProvider.swift; sourceTree = "<group>"; };
+		326E732620BC2339006D2DBD /* ADPermissionProviderConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADPermissionProviderConfiguration.swift; sourceTree = "<group>"; };
+		326E732B20BC23BE006D2DBD /* ADResourceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADResourceType.swift; sourceTree = "<group>"; };
+		326E733020BC28B4006D2DBD /* ADResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADResponse.swift; sourceTree = "<group>"; };
+		326E733520BC2AB8006D2DBD /* ADResponseMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADResponseMetadata.swift; sourceTree = "<group>"; };
+		326E734420BC95E7006D2DBD /* ADDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADDatabase.swift; sourceTree = "<group>"; };
+		326E734920BC9B9B006D2DBD /* ADResources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADResources.swift; sourceTree = "<group>"; };
+		326E734E20BC9D07006D2DBD /* ObjectiveCBridgeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCBridgeable.swift; sourceTree = "<group>"; };
+		326E735320BCA3FC006D2DBD /* ADDocumentCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADDocumentCollection.swift; sourceTree = "<group>"; };
 		327996FE209C830C0062A374 /* ResourceWriteOperationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceWriteOperationQueue.swift; sourceTree = "<group>"; };
 		329AA645209CEF470007A955 /* ResourceSystemProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceSystemProperties.swift; sourceTree = "<group>"; };
+		329C7DAE20BEB3EE00A49453 /* ADQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADQuery.swift; sourceTree = "<group>"; };
+		329C7DB320BEC28000A49453 /* OfflineReadTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OfflineReadTests.swift; sourceTree = "<group>"; };
+		329C7DB720BECBEB00A49453 /* ADAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADAttachment.swift; sourceTree = "<group>"; };
+		329C7DBC20BEDCF200A49453 /* ADStoredProcedure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADStoredProcedure.swift; sourceTree = "<group>"; };
+		329C7DC120BEE3B500A49453 /* ADUserDefinedFunction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADUserDefinedFunction.swift; sourceTree = "<group>"; };
+		329C7DC620BEE7A600A49453 /* ADTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADTrigger.swift; sourceTree = "<group>"; };
+		329C7DCB20BEF15D00A49453 /* ADUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADUser.swift; sourceTree = "<group>"; };
+		329C7DD020BEF9E100A49453 /* ADResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADResource.swift; sourceTree = "<group>"; };
+		329C7DD520BEFDF600A49453 /* ADOffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADOffer.swift; sourceTree = "<group>"; };
+		329C7DDA20BF08DF00A49453 /* ADSupportsPermissionToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADSupportsPermissionToken.swift; sourceTree = "<group>"; };
+		329C7DDF20BF0CED00A49453 /* SwiftWrappers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftWrappers.swift; sourceTree = "<group>"; };
 		32A5030620A1D16F000C5948 /* ResourceEncryptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceEncryptor.swift; sourceTree = "<group>"; };
+		32A77CD520C0566E00846397 /* ADPartitionKeyDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADPartitionKeyDefinition.swift; sourceTree = "<group>"; };
+		32A77CDA20C0569C00846397 /* ADIndexingMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADIndexingMode.swift; sourceTree = "<group>"; };
+		32A77CDF20C056D900846397 /* ADIndexKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADIndexKind.swift; sourceTree = "<group>"; };
+		32A77CE420C056F100846397 /* ADIndexDataType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADIndexDataType.swift; sourceTree = "<group>"; };
+		32A77CE920C0570E00846397 /* ADIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADIndex.swift; sourceTree = "<group>"; };
+		32A77CEE20C0573000846397 /* ADIncludedPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADIncludedPath.swift; sourceTree = "<group>"; };
+		32A77CF320C0574A00846397 /* ADExcludedPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADExcludedPath.swift; sourceTree = "<group>"; };
+		32A77CF820C0576600846397 /* ADIndexingPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADIndexingPolicy.swift; sourceTree = "<group>"; };
 		32AABD1D20AC9FB900F66DC6 /* OfflineWriteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineWriteTests.swift; sourceTree = "<group>"; };
 		32AABD2120ACA05400F66DC6 /* MockReachabilityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockReachabilityManager.swift; sourceTree = "<group>"; };
 		32AABD2620ACA83300F66DC6 /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
 		32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseMetadataTests.swift; sourceTree = "<group>"; };
 		32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceWriteOperation.swift; sourceTree = "<group>"; };
+		32FB702720BD5444009A35D9 /* ADPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADPermission.swift; sourceTree = "<group>"; };
+		32FB703120BD8070009A35D9 /* ADCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADCodable.swift; sourceTree = "<group>"; };
+		32FB703620BD9B11009A35D9 /* ADDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADDocument.swift; sourceTree = "<group>"; };
 		9302CE422059A3A5000F6885 /* AzureCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AzureCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9302CE442059A3C5000F6885 /* AzureCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AzureCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9302CE462059A3D2000F6885 /* AzureCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AzureCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -474,6 +649,63 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		326E730B20BC1318006D2DBD /* Objective-C */ = {
+			isa = PBXGroup;
+			children = (
+				32A77CD420C0564800846397 /* DocumentCollection */,
+				329C7DB720BECBEB00A49453 /* ADAttachment.swift */,
+				32FB703120BD8070009A35D9 /* ADCodable.swift */,
+				326E734420BC95E7006D2DBD /* ADDatabase.swift */,
+				3257CCA520C1D701004E51FF /* ADDocument.h */,
+				3257CCA020C1CCE4004E51FF /* ADDocument.m */,
+				32FB703620BD9B11009A35D9 /* ADDocument.swift */,
+				329C7DD520BEFDF600A49453 /* ADOffer.swift */,
+				32FB702720BD5444009A35D9 /* ADPermission.swift */,
+				326E731C20BC2185006D2DBD /* ADPermissionMode.swift */,
+				326E733520BC2AB8006D2DBD /* ADResponseMetadata.swift */,
+				329C7DD020BEF9E100A49453 /* ADResource.swift */,
+				326E734920BC9B9B006D2DBD /* ADResources.swift */,
+				329C7DBC20BEDCF200A49453 /* ADStoredProcedure.swift */,
+				329C7DC620BEE7A600A49453 /* ADTrigger.swift */,
+				329C7DCB20BEF15D00A49453 /* ADUser.swift */,
+				329C7DC120BEE3B500A49453 /* ADUserDefinedFunction.swift */,
+			);
+			path = "Objective-C";
+			sourceTree = "<group>";
+		};
+		326E731620BC2032006D2DBD /* Objective-C */ = {
+			isa = PBXGroup;
+			children = (
+				326E731720BC2041006D2DBD /* ADAzureData.swift */,
+				326E732120BC22EE006D2DBD /* ADPermissionProvider.swift */,
+				326E732620BC2339006D2DBD /* ADPermissionProviderConfiguration.swift */,
+				329C7DAE20BEB3EE00A49453 /* ADQuery.swift */,
+				326E732B20BC23BE006D2DBD /* ADResourceType.swift */,
+				326E733020BC28B4006D2DBD /* ADResponse.swift */,
+				329C7DDA20BF08DF00A49453 /* ADSupportsPermissionToken.swift */,
+				326E734E20BC9D07006D2DBD /* ObjectiveCBridgeable.swift */,
+				3257CC5420C1486A004E51FF /* ObjectiveCUtilities.swift */,
+				329C7DDF20BF0CED00A49453 /* SwiftWrappers.swift */,
+			);
+			path = "Objective-C";
+			sourceTree = "<group>";
+		};
+		32A77CD420C0564800846397 /* DocumentCollection */ = {
+			isa = PBXGroup;
+			children = (
+				326E735320BCA3FC006D2DBD /* ADDocumentCollection.swift */,
+				32A77CF320C0574A00846397 /* ADExcludedPath.swift */,
+				32A77CEE20C0573000846397 /* ADIncludedPath.swift */,
+				32A77CE920C0570E00846397 /* ADIndex.swift */,
+				32A77CE420C056F100846397 /* ADIndexDataType.swift */,
+				32A77CDF20C056D900846397 /* ADIndexKind.swift */,
+				32A77CDA20C0569C00846397 /* ADIndexingMode.swift */,
+				32A77CF820C0576600846397 /* ADIndexingPolicy.swift */,
+				32A77CD520C0566E00846397 /* ADPartitionKeyDefinition.swift */,
+			);
+			path = DocumentCollection;
+			sourceTree = "<group>";
+		};
 		32AABD2520ACA81D00F66DC6 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
@@ -486,6 +718,7 @@
 		B52240181FB33CD000D0343F /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				326E731620BC2032006D2DBD /* Objective-C */,
 				B52240341FB33CD000D0343F /* AzureData.swift */,
 				B522401B1FB33CD000D0343F /* AzureDataExtensions.swift */,
 				9358A971207E435200B25D67 /* ConflictStrategy.swift */,
@@ -585,7 +818,7 @@
 		B55AEFE81FB34D6500F7BEED /* Domain */ = {
 			isa = PBXGroup;
 			children = (
-				3276EA12208F3450003F6382 /* OfflineReadTests.swift */,
+				329C7DB320BEC28000A49453 /* OfflineReadTests.swift */,
 				32AABD1D20AC9FB900F66DC6 /* OfflineWriteTests.swift */,
 				B522403D1FB33D1200D0343F /* QueryTests.swift */,
 				32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */,
@@ -597,6 +830,7 @@
 		B58361B71FBA1339001CEC66 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				326E730B20BC1318006D2DBD /* Objective-C */,
 				B58361B81FBA1384001CEC66 /* CodableResource.swift */,
 				323A90E8207F976400537769 /* CodableResources.swift */,
 				B5B6AC281FBA84C400B93106 /* CodableDictionary.swift */,
@@ -665,6 +899,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3257CCA720C1D701004E51FF /* ADDocument.h in Headers */,
 				B52240511FB33DAB00D0343F /* AzureData.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -673,6 +908,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3257CCA820C1D701004E51FF /* ADDocument.h in Headers */,
 				B52240501FB33DA900D0343F /* AzureData.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -681,6 +917,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3257CCA920C1D701004E51FF /* ADDocument.h in Headers */,
 				B52240F71FB3409D00D0343F /* AzureData.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -689,6 +926,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3257CCA620C1D701004E51FF /* ADDocument.h in Headers */,
 				B52240521FB33DAD00D0343F /* AzureData.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -834,7 +1072,7 @@
 				TargetAttributes = {
 					B5223FB61FB33A9F00D0343F = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 0930;
 						ProvisioningStyle = Manual;
 					};
 					B5223FBE1FB33A9F00D0343F = {
@@ -843,7 +1081,7 @@
 					};
 					B5223FD21FB33B0F00D0343F = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 0930;
 						ProvisioningStyle = Automatic;
 					};
 					B5223FDA1FB33B0F00D0343F = {
@@ -852,12 +1090,12 @@
 					};
 					B5223FEE1FB33B2600D0343F = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 0930;
 						ProvisioningStyle = Automatic;
 					};
 					B5F76C381F96A7AF001E8B11 = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 0930;
 						ProvisioningStyle = Automatic;
 					};
 					B5F76C411F96A7AF001E8B11 = {
@@ -951,51 +1189,85 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				326E735520BCA3FC006D2DBD /* ADDocumentCollection.swift in Sources */,
+				329C7DCD20BEF15D00A49453 /* ADUser.swift in Sources */,
+				32A77CEB20C0570E00846397 /* ADIndex.swift in Sources */,
+				329C7DD720BEFDF600A49453 /* ADOffer.swift in Sources */,
 				B5B6AC2A1FBA84C400B93106 /* CodableDictionary.swift in Sources */,
+				329C7DBE20BEDCF200A49453 /* ADStoredProcedure.swift in Sources */,
 				B507D4F21FBB722000B2D18D /* Conflict.swift in Sources */,
 				329AA647209CEF470007A955 /* ResourceSystemProperties.swift in Sources */,
+				32FB702920BD5444009A35D9 /* ADPermission.swift in Sources */,
+				329C7DE120BF0CED00A49453 /* SwiftWrappers.swift in Sources */,
 				B58361CE1FBA1439001CEC66 /* Attachment.swift in Sources */,
+				326E735020BC9D07006D2DBD /* ObjectiveCBridgeable.swift in Sources */,
+				326E732320BC22EE006D2DBD /* ADPermissionProvider.swift in Sources */,
 				9319DEEA20698C3D0083475D /* PermissionProvider.swift in Sources */,
 				9319DEF920698FB90083475D /* PermissionCache.swift in Sources */,
+				329C7DB020BEB3EE00A49453 /* ADQuery.swift in Sources */,
+				326E731920BC2041006D2DBD /* ADAzureData.swift in Sources */,
 				323A90EA207F976400537769 /* CodableResources.swift in Sources */,
 				930B2F491FFD56AB00F86BF1 /* DictionaryDocument.swift in Sources */,
+				326E733220BC28B4006D2DBD /* ADResponse.swift in Sources */,
+				32FB703320BD8070009A35D9 /* ADCodable.swift in Sources */,
+				326E732D20BC23BE006D2DBD /* ADResourceType.swift in Sources */,
 				B58361B31FB78F7A001CEC66 /* Resources.swift in Sources */,
+				32A77CFA20C0576600846397 /* ADIndexingPolicy.swift in Sources */,
 				93F9ACCD1FC0CA4800AC240C /* DocumentClientError.swift in Sources */,
+				32FB703820BD9B11009A35D9 /* ADDocument.swift in Sources */,
 				B58361D81FBA16F9001CEC66 /* Permission.swift in Sources */,
+				326E731E20BC2185006D2DBD /* ADPermissionMode.swift in Sources */,
 				93F9ACD21FC0D01400AC240C /* ResourceError.swift in Sources */,
+				32A77CE620C056F100846397 /* ADIndexDataType.swift in Sources */,
 				B58361C41FBA13B0001CEC66 /* DocumentCollection.swift in Sources */,
 				B5B6AC251FBA4B3900B93106 /* Query.swift in Sources */,
 				93935D9C20585C8600F1832A /* PermissionMode.swift in Sources */,
+				326E732820BC2339006D2DBD /* ADPermissionProviderConfiguration.swift in Sources */,
 				32532A5C207825A1002BFFCA /* ResponseMetadata.swift in Sources */,
 				9358A973207E435200B25D67 /* ConflictStrategy.swift in Sources */,
+				32A77CF020C0573000846397 /* ADIncludedPath.swift in Sources */,
+				329C7DC820BEE7A600A49453 /* ADTrigger.swift in Sources */,
+				32A77CE120C056D900846397 /* ADIndexKind.swift in Sources */,
 				323B71AB207E6B75000F20F6 /* ResourceRequestError.swift in Sources */,
 				9317A81820656ED100338B63 /* ResourceOracle.swift in Sources */,
 				931EA5C41FBE6920003CCFF4 /* DocumentClientExtensions.swift in Sources */,
 				B58361B41FB78F7A001CEC66 /* Response.swift in Sources */,
 				B52241021FB3409F00D0343F /* AzureData.swift in Sources */,
 				B52240B21FB3409000D0343F /* ResourceType.swift in Sources */,
+				3257CCA220C1CCE4004E51FF /* ADDocument.m in Sources */,
+				3257CC5620C1486A004E51FF /* ObjectiveCUtilities.swift in Sources */,
 				9319DEF420698F260083475D /* PermissionProviderError.swift in Sources */,
 				B58361F11FBA19A7001CEC66 /* DatabaseAccount.swift in Sources */,
 				323AE94B2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */,
 				B58361E71FBA17D8001CEC66 /* User.swift in Sources */,
+				329C7DB920BECBEB00A49453 /* ADAttachment.swift in Sources */,
 				B52241051FB3409F00D0343F /* UtilityExtensions.swift in Sources */,
 				9319DF032069DD7B0083475D /* ResourceTokenProvider.swift in Sources */,
+				32A77CDC20C0569C00846397 /* ADIndexingMode.swift in Sources */,
 				B58361EC1FBA17E8001CEC66 /* UserDefinedFunction.swift in Sources */,
 				B58361BF1FBA13A0001CEC66 /* Document.swift in Sources */,
+				329C7DDC20BF08DF00A49453 /* ADSupportsPermissionToken.swift in Sources */,
 				B58361D31FBA15A8001CEC66 /* Offer.swift in Sources */,
 				B58361C91FBA13D8001CEC66 /* Database.swift in Sources */,
 				B58361E21FBA17C8001CEC66 /* Trigger.swift in Sources */,
 				B58361DD1FBA17B5001CEC66 /* StoredProcedure.swift in Sources */,
 				9316F450206A977F00D7BA8B /* ResourceLocation.swift in Sources */,
+				326E734620BC95E7006D2DBD /* ADDatabase.swift in Sources */,
+				32A77CD720C0566E00846397 /* ADPartitionKeyDefinition.swift in Sources */,
+				326E734B20BC9B9B006D2DBD /* ADResources.swift in Sources */,
 				932F01342076AC5A001D708B /* ResourceCache.swift in Sources */,
 				9319DEEF20698C840083475D /* PermissionProviderConfiguration.swift in Sources */,
 				32EB2C1E209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */,
 				B52240961FB3407C00D0343F /* AzureDataExtensions.swift in Sources */,
 				32A5030820A1D16F000C5948 /* ResourceEncryptor.swift in Sources */,
+				329C7DC320BEE3B500A49453 /* ADUserDefinedFunction.swift in Sources */,
 				32799700209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */,
+				32A77CF520C0574A00846397 /* ADExcludedPath.swift in Sources */,
 				B58361BA1FBA1385001CEC66 /* CodableResource.swift in Sources */,
 				B58361A71FB78F73001CEC66 /* DocumentClient.swift in Sources */,
 				93B7240C2064560F00984CA8 /* MSHttpHeader.swift in Sources */,
+				326E733720BC2AB8006D2DBD /* ADResponseMetadata.swift in Sources */,
+				329C7DD220BEF9E100A49453 /* ADResource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1018,10 +1290,10 @@
 				932832E72072CD9E0075ECC7 /* ExamplePermissionProviderTests.swift in Sources */,
 				B522406E1FB33DF800D0343F /* TriggerTests.swift in Sources */,
 				9317A81D2065763700338B63 /* ResourceOracleTests.swift in Sources */,
-				3276EA14208F3450003F6382 /* OfflineReadTests.swift in Sources */,
 				32AABD2320ACA05400F66DC6 /* MockReachabilityManager.swift in Sources */,
 				B52240701FB33DF800D0343F /* PermissionTests.swift in Sources */,
 				B52240681FB33DF800D0343F /* StoredProcedureTests.swift in Sources */,
+				329C7DB520BEC28000A49453 /* OfflineReadTests.swift in Sources */,
 				B52240771FB33DF800D0343F /* AzureDataTests.swift in Sources */,
 				B522406A1FB33DF800D0343F /* QueryTests.swift in Sources */,
 				3236FBDE209160F70002FB5F /* _AzureDataTests.swift in Sources */,
@@ -1041,51 +1313,85 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				326E735620BCA3FC006D2DBD /* ADDocumentCollection.swift in Sources */,
+				329C7DCE20BEF15D00A49453 /* ADUser.swift in Sources */,
+				32A77CEC20C0570E00846397 /* ADIndex.swift in Sources */,
+				329C7DD820BEFDF600A49453 /* ADOffer.swift in Sources */,
 				B5B6AC2B1FBA84C400B93106 /* CodableDictionary.swift in Sources */,
+				329C7DBF20BEDCF200A49453 /* ADStoredProcedure.swift in Sources */,
 				B507D4F31FBB722000B2D18D /* Conflict.swift in Sources */,
 				329AA648209CEF470007A955 /* ResourceSystemProperties.swift in Sources */,
+				32FB702A20BD5444009A35D9 /* ADPermission.swift in Sources */,
+				329C7DE220BF0CED00A49453 /* SwiftWrappers.swift in Sources */,
 				B58361CF1FBA1439001CEC66 /* Attachment.swift in Sources */,
+				326E735120BC9D07006D2DBD /* ObjectiveCBridgeable.swift in Sources */,
+				326E732420BC22EE006D2DBD /* ADPermissionProvider.swift in Sources */,
 				9319DEEB20698C3D0083475D /* PermissionProvider.swift in Sources */,
 				9319DEFA20698FB90083475D /* PermissionCache.swift in Sources */,
+				329C7DB120BEB3EE00A49453 /* ADQuery.swift in Sources */,
+				326E731A20BC2041006D2DBD /* ADAzureData.swift in Sources */,
 				323A90EB207F976400537769 /* CodableResources.swift in Sources */,
 				930B2F4A1FFD56AB00F86BF1 /* DictionaryDocument.swift in Sources */,
+				326E733320BC28B4006D2DBD /* ADResponse.swift in Sources */,
+				32FB703420BD8070009A35D9 /* ADCodable.swift in Sources */,
+				326E732E20BC23BE006D2DBD /* ADResourceType.swift in Sources */,
 				B58361AE1FB78F7A001CEC66 /* Resources.swift in Sources */,
+				32A77CFB20C0576600846397 /* ADIndexingPolicy.swift in Sources */,
 				93F9ACCE1FC0CA4800AC240C /* DocumentClientError.swift in Sources */,
+				32FB703920BD9B11009A35D9 /* ADDocument.swift in Sources */,
 				B58361D91FBA16F9001CEC66 /* Permission.swift in Sources */,
+				326E731F20BC2185006D2DBD /* ADPermissionMode.swift in Sources */,
 				93F9ACD31FC0D01400AC240C /* ResourceError.swift in Sources */,
+				32A77CE720C056F100846397 /* ADIndexDataType.swift in Sources */,
 				B58361C51FBA13B0001CEC66 /* DocumentCollection.swift in Sources */,
 				B5B6AC261FBA4B3900B93106 /* Query.swift in Sources */,
 				93935D9D20585C8600F1832A /* PermissionMode.swift in Sources */,
+				326E732920BC2339006D2DBD /* ADPermissionProviderConfiguration.swift in Sources */,
 				32532A5E207825A1002BFFCA /* ResponseMetadata.swift in Sources */,
 				9358A974207E435200B25D67 /* ConflictStrategy.swift in Sources */,
+				32A77CF120C0573000846397 /* ADIncludedPath.swift in Sources */,
+				329C7DC920BEE7A600A49453 /* ADTrigger.swift in Sources */,
+				32A77CE220C056D900846397 /* ADIndexKind.swift in Sources */,
 				323B71AC207E6B75000F20F6 /* ResourceRequestError.swift in Sources */,
 				9317A81920656ED100338B63 /* ResourceOracle.swift in Sources */,
 				931EA5C61FBE6922003CCFF4 /* DocumentClientExtensions.swift in Sources */,
 				B58361AF1FB78F7A001CEC66 /* Response.swift in Sources */,
 				B52240FD1FB3409E00D0343F /* AzureData.swift in Sources */,
 				B52240C71FB3409100D0343F /* ResourceType.swift in Sources */,
+				3257CCA320C1CCE4004E51FF /* ADDocument.m in Sources */,
+				3257CC5720C1486A004E51FF /* ObjectiveCUtilities.swift in Sources */,
 				9319DEF520698F260083475D /* PermissionProviderError.swift in Sources */,
 				B58361F21FBA19A7001CEC66 /* DatabaseAccount.swift in Sources */,
 				323AE94C2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */,
 				B58361E81FBA17D8001CEC66 /* User.swift in Sources */,
+				329C7DBA20BECBEB00A49453 /* ADAttachment.swift in Sources */,
 				B52241001FB3409E00D0343F /* UtilityExtensions.swift in Sources */,
 				9319DF042069DD7B0083475D /* ResourceTokenProvider.swift in Sources */,
+				32A77CDD20C0569C00846397 /* ADIndexingMode.swift in Sources */,
 				B58361ED1FBA17E8001CEC66 /* UserDefinedFunction.swift in Sources */,
 				B58361C01FBA13A0001CEC66 /* Document.swift in Sources */,
+				329C7DDD20BF08DF00A49453 /* ADSupportsPermissionToken.swift in Sources */,
 				B58361D41FBA15A8001CEC66 /* Offer.swift in Sources */,
 				B58361CA1FBA13D8001CEC66 /* Database.swift in Sources */,
 				B58361E31FBA17C8001CEC66 /* Trigger.swift in Sources */,
 				B58361DE1FBA17B5001CEC66 /* StoredProcedure.swift in Sources */,
 				9316F451206A977F00D7BA8B /* ResourceLocation.swift in Sources */,
+				326E734720BC95E7006D2DBD /* ADDatabase.swift in Sources */,
+				32A77CD820C0566E00846397 /* ADPartitionKeyDefinition.swift in Sources */,
+				326E734C20BC9B9B006D2DBD /* ADResources.swift in Sources */,
 				932F01352076AC5A001D708B /* ResourceCache.swift in Sources */,
 				9319DEF020698C840083475D /* PermissionProviderConfiguration.swift in Sources */,
 				32EB2C1F209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */,
 				B52240991FB3407D00D0343F /* AzureDataExtensions.swift in Sources */,
 				32A5030920A1D16F000C5948 /* ResourceEncryptor.swift in Sources */,
+				329C7DC420BEE3B500A49453 /* ADUserDefinedFunction.swift in Sources */,
 				32799701209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */,
+				32A77CF620C0574A00846397 /* ADExcludedPath.swift in Sources */,
 				B58361BB1FBA1385001CEC66 /* CodableResource.swift in Sources */,
 				B58361A61FB78F73001CEC66 /* DocumentClient.swift in Sources */,
 				93B7240D2064560F00984CA8 /* MSHttpHeader.swift in Sources */,
+				326E733820BC2AB8006D2DBD /* ADResponseMetadata.swift in Sources */,
+				329C7DD320BEF9E100A49453 /* ADResource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1108,10 +1414,10 @@
 				932832E82072CD9E0075ECC7 /* ExamplePermissionProviderTests.swift in Sources */,
 				B52240821FB33DFA00D0343F /* TriggerTests.swift in Sources */,
 				9317A81E2065763700338B63 /* ResourceOracleTests.swift in Sources */,
-				3276EA15208F3450003F6382 /* OfflineReadTests.swift in Sources */,
 				32AABD2420ACA05400F66DC6 /* MockReachabilityManager.swift in Sources */,
 				B52240841FB33DFA00D0343F /* PermissionTests.swift in Sources */,
 				B522407C1FB33DFA00D0343F /* StoredProcedureTests.swift in Sources */,
+				329C7DB620BEC28000A49453 /* OfflineReadTests.swift in Sources */,
 				B522408B1FB33DFA00D0343F /* AzureDataTests.swift in Sources */,
 				B522407E1FB33DFA00D0343F /* QueryTests.swift in Sources */,
 				3236FBDF209160F70002FB5F /* _AzureDataTests.swift in Sources */,
@@ -1131,51 +1437,85 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				326E735720BCA3FC006D2DBD /* ADDocumentCollection.swift in Sources */,
+				329C7DCF20BEF15D00A49453 /* ADUser.swift in Sources */,
+				32A77CED20C0570E00846397 /* ADIndex.swift in Sources */,
+				329C7DD920BEFDF600A49453 /* ADOffer.swift in Sources */,
 				B5B6AC2C1FBA84C400B93106 /* CodableDictionary.swift in Sources */,
+				329C7DC020BEDCF200A49453 /* ADStoredProcedure.swift in Sources */,
 				B507D4F41FBB722000B2D18D /* Conflict.swift in Sources */,
 				329AA649209CEF470007A955 /* ResourceSystemProperties.swift in Sources */,
+				32FB702B20BD5444009A35D9 /* ADPermission.swift in Sources */,
+				329C7DE320BF0CED00A49453 /* SwiftWrappers.swift in Sources */,
 				B58361D01FBA1439001CEC66 /* Attachment.swift in Sources */,
+				326E735220BC9D07006D2DBD /* ObjectiveCBridgeable.swift in Sources */,
+				326E732520BC22EE006D2DBD /* ADPermissionProvider.swift in Sources */,
 				9319DEEC20698C3D0083475D /* PermissionProvider.swift in Sources */,
 				9319DEFB20698FB90083475D /* PermissionCache.swift in Sources */,
+				329C7DB220BEB3EE00A49453 /* ADQuery.swift in Sources */,
+				326E731B20BC2041006D2DBD /* ADAzureData.swift in Sources */,
 				323A90EC207F976400537769 /* CodableResources.swift in Sources */,
 				930B2F4B1FFD56AB00F86BF1 /* DictionaryDocument.swift in Sources */,
+				326E733420BC28B4006D2DBD /* ADResponse.swift in Sources */,
+				32FB703520BD8070009A35D9 /* ADCodable.swift in Sources */,
+				326E732F20BC23BE006D2DBD /* ADResourceType.swift in Sources */,
 				B58361A91FB78F78001CEC66 /* Resources.swift in Sources */,
+				32A77CFC20C0576600846397 /* ADIndexingPolicy.swift in Sources */,
 				93F9ACCF1FC0CA4800AC240C /* DocumentClientError.swift in Sources */,
+				32FB703A20BD9B11009A35D9 /* ADDocument.swift in Sources */,
 				B58361DA1FBA16F9001CEC66 /* Permission.swift in Sources */,
+				326E732020BC2185006D2DBD /* ADPermissionMode.swift in Sources */,
 				93F9ACD41FC0D01400AC240C /* ResourceError.swift in Sources */,
+				32A77CE820C056F100846397 /* ADIndexDataType.swift in Sources */,
 				B58361C61FBA13B0001CEC66 /* DocumentCollection.swift in Sources */,
 				B5B6AC271FBA4B3900B93106 /* Query.swift in Sources */,
 				93935D9E20585C8600F1832A /* PermissionMode.swift in Sources */,
+				326E732A20BC2339006D2DBD /* ADPermissionProviderConfiguration.swift in Sources */,
 				32532A60207825A1002BFFCA /* ResponseMetadata.swift in Sources */,
 				9358A975207E435200B25D67 /* ConflictStrategy.swift in Sources */,
+				32A77CF220C0573000846397 /* ADIncludedPath.swift in Sources */,
+				329C7DCA20BEE7A600A49453 /* ADTrigger.swift in Sources */,
+				32A77CE320C056D900846397 /* ADIndexKind.swift in Sources */,
 				323B71AD207E6B75000F20F6 /* ResourceRequestError.swift in Sources */,
 				9317A81A20656ED100338B63 /* ResourceOracle.swift in Sources */,
 				931EA5C51FBE6922003CCFF4 /* DocumentClientExtensions.swift in Sources */,
 				B58361AA1FB78F78001CEC66 /* Response.swift in Sources */,
 				B52240F81FB3409D00D0343F /* AzureData.swift in Sources */,
 				B52240DC1FB3409200D0343F /* ResourceType.swift in Sources */,
+				3257CCA420C1CCE4004E51FF /* ADDocument.m in Sources */,
+				3257CC5820C1486A004E51FF /* ObjectiveCUtilities.swift in Sources */,
 				9319DEF620698F260083475D /* PermissionProviderError.swift in Sources */,
 				B58361F31FBA19A7001CEC66 /* DatabaseAccount.swift in Sources */,
 				323AE94D2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */,
 				B58361E91FBA17D8001CEC66 /* User.swift in Sources */,
+				329C7DBB20BECBEB00A49453 /* ADAttachment.swift in Sources */,
 				B52240FB1FB3409D00D0343F /* UtilityExtensions.swift in Sources */,
 				9319DF052069DD7B0083475D /* ResourceTokenProvider.swift in Sources */,
+				32A77CDE20C0569C00846397 /* ADIndexingMode.swift in Sources */,
 				B58361EE1FBA17E8001CEC66 /* UserDefinedFunction.swift in Sources */,
 				B58361C11FBA13A0001CEC66 /* Document.swift in Sources */,
+				329C7DDE20BF08DF00A49453 /* ADSupportsPermissionToken.swift in Sources */,
 				B58361D51FBA15A8001CEC66 /* Offer.swift in Sources */,
 				B58361CB1FBA13D8001CEC66 /* Database.swift in Sources */,
 				B58361E41FBA17C8001CEC66 /* Trigger.swift in Sources */,
 				B58361DF1FBA17B5001CEC66 /* StoredProcedure.swift in Sources */,
 				9316F452206A977F00D7BA8B /* ResourceLocation.swift in Sources */,
+				326E734820BC95E7006D2DBD /* ADDatabase.swift in Sources */,
+				32A77CD920C0566E00846397 /* ADPartitionKeyDefinition.swift in Sources */,
+				326E734D20BC9B9B006D2DBD /* ADResources.swift in Sources */,
 				932F01362076AC5A001D708B /* ResourceCache.swift in Sources */,
 				9319DEF120698C840083475D /* PermissionProviderConfiguration.swift in Sources */,
 				32EB2C20209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */,
 				B522409C1FB3407E00D0343F /* AzureDataExtensions.swift in Sources */,
 				32A5030A20A1D16F000C5948 /* ResourceEncryptor.swift in Sources */,
+				329C7DC520BEE3B500A49453 /* ADUserDefinedFunction.swift in Sources */,
 				32799702209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */,
+				32A77CF720C0574A00846397 /* ADExcludedPath.swift in Sources */,
 				B58361BC1FBA1385001CEC66 /* CodableResource.swift in Sources */,
 				B58361A51FB78F71001CEC66 /* DocumentClient.swift in Sources */,
 				93B7240E2064560F00984CA8 /* MSHttpHeader.swift in Sources */,
+				326E733920BC2AB8006D2DBD /* ADResponseMetadata.swift in Sources */,
+				329C7DD420BEF9E100A49453 /* ADResource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1183,51 +1523,85 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				326E735420BCA3FC006D2DBD /* ADDocumentCollection.swift in Sources */,
+				329C7DCC20BEF15D00A49453 /* ADUser.swift in Sources */,
+				32A77CEA20C0570E00846397 /* ADIndex.swift in Sources */,
+				329C7DD620BEFDF600A49453 /* ADOffer.swift in Sources */,
 				B5B6AC291FBA84C400B93106 /* CodableDictionary.swift in Sources */,
+				329C7DBD20BEDCF200A49453 /* ADStoredProcedure.swift in Sources */,
 				B507D4F11FBB722000B2D18D /* Conflict.swift in Sources */,
 				329AA646209CEF470007A955 /* ResourceSystemProperties.swift in Sources */,
+				32FB702820BD5444009A35D9 /* ADPermission.swift in Sources */,
+				329C7DE020BF0CED00A49453 /* SwiftWrappers.swift in Sources */,
 				B58361CD1FBA1439001CEC66 /* Attachment.swift in Sources */,
+				326E734F20BC9D07006D2DBD /* ObjectiveCBridgeable.swift in Sources */,
+				326E732220BC22EE006D2DBD /* ADPermissionProvider.swift in Sources */,
 				9319DEE920698C3D0083475D /* PermissionProvider.swift in Sources */,
 				9319DEF820698FB90083475D /* PermissionCache.swift in Sources */,
+				329C7DAF20BEB3EE00A49453 /* ADQuery.swift in Sources */,
+				326E731820BC2041006D2DBD /* ADAzureData.swift in Sources */,
 				323A90E9207F976400537769 /* CodableResources.swift in Sources */,
 				930B2F481FFD56AB00F86BF1 /* DictionaryDocument.swift in Sources */,
+				326E733120BC28B4006D2DBD /* ADResponse.swift in Sources */,
+				32FB703220BD8070009A35D9 /* ADCodable.swift in Sources */,
+				326E732C20BC23BE006D2DBD /* ADResourceType.swift in Sources */,
 				B58361D71FBA16F9001CEC66 /* Permission.swift in Sources */,
+				32A77CF920C0576600846397 /* ADIndexingPolicy.swift in Sources */,
 				93F9ACCC1FC0CA4800AC240C /* DocumentClientError.swift in Sources */,
+				32FB703720BD9B11009A35D9 /* ADDocument.swift in Sources */,
 				B58361C31FBA13B0001CEC66 /* DocumentCollection.swift in Sources */,
+				326E731D20BC2185006D2DBD /* ADPermissionMode.swift in Sources */,
 				93F9ACD11FC0D01400AC240C /* ResourceError.swift in Sources */,
+				32A77CE520C056F100846397 /* ADIndexDataType.swift in Sources */,
 				B583619A1FB779B6001CEC66 /* Response.swift in Sources */,
 				B5B6AC241FBA4B3900B93106 /* Query.swift in Sources */,
 				93935D9B20585C8600F1832A /* PermissionMode.swift in Sources */,
+				326E732720BC2339006D2DBD /* ADPermissionProviderConfiguration.swift in Sources */,
 				32532A5A207825A1002BFFCA /* ResponseMetadata.swift in Sources */,
 				9358A972207E435200B25D67 /* ConflictStrategy.swift in Sources */,
+				32A77CEF20C0573000846397 /* ADIncludedPath.swift in Sources */,
+				329C7DC720BEE7A600A49453 /* ADTrigger.swift in Sources */,
+				32A77CE020C056D900846397 /* ADIndexKind.swift in Sources */,
 				323B71AA207E6B75000F20F6 /* ResourceRequestError.swift in Sources */,
 				9317A81720656ED100338B63 /* ResourceOracle.swift in Sources */,
 				931EA5BF1FBE201F003CCFF4 /* DocumentClientExtensions.swift in Sources */,
 				B583619D1FB77A70001CEC66 /* Resources.swift in Sources */,
 				B52241071FB3409F00D0343F /* AzureData.swift in Sources */,
 				B58361F01FBA19A7001CEC66 /* DatabaseAccount.swift in Sources */,
+				3257CCA120C1CCE4004E51FF /* ADDocument.m in Sources */,
+				3257CC5520C1486A004E51FF /* ObjectiveCUtilities.swift in Sources */,
 				9319DEF320698F260083475D /* PermissionProviderError.swift in Sources */,
 				B522409D1FB3408E00D0343F /* ResourceType.swift in Sources */,
 				323AE94A2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */,
 				B58361E61FBA17D8001CEC66 /* User.swift in Sources */,
+				329C7DB820BECBEB00A49453 /* ADAttachment.swift in Sources */,
 				B58361EB1FBA17E8001CEC66 /* UserDefinedFunction.swift in Sources */,
 				9319DF022069DD7B0083475D /* ResourceTokenProvider.swift in Sources */,
+				32A77CDB20C0569C00846397 /* ADIndexingMode.swift in Sources */,
 				B58361BE1FBA13A0001CEC66 /* Document.swift in Sources */,
 				B58361D21FBA15A8001CEC66 /* Offer.swift in Sources */,
+				329C7DDB20BF08DF00A49453 /* ADSupportsPermissionToken.swift in Sources */,
 				B58361C81FBA13D8001CEC66 /* Database.swift in Sources */,
 				B58361E11FBA17C8001CEC66 /* Trigger.swift in Sources */,
 				B58361DC1FBA17B5001CEC66 /* StoredProcedure.swift in Sources */,
 				B522410A1FB3409F00D0343F /* UtilityExtensions.swift in Sources */,
 				9316F44F206A977F00D7BA8B /* ResourceLocation.swift in Sources */,
+				326E734520BC95E7006D2DBD /* ADDatabase.swift in Sources */,
+				32A77CD620C0566E00846397 /* ADPartitionKeyDefinition.swift in Sources */,
+				326E734A20BC9B9B006D2DBD /* ADResources.swift in Sources */,
 				932F01332076AC5A001D708B /* ResourceCache.swift in Sources */,
 				9319DEEE20698C840083475D /* PermissionProviderConfiguration.swift in Sources */,
 				32EB2C1D209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */,
 				B583619F1FB78763001CEC66 /* DocumentClient.swift in Sources */,
 				32A5030720A1D16F000C5948 /* ResourceEncryptor.swift in Sources */,
+				329C7DC220BEE3B500A49453 /* ADUserDefinedFunction.swift in Sources */,
 				327996FF209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */,
+				32A77CF420C0574A00846397 /* ADExcludedPath.swift in Sources */,
 				B58361B91FBA1385001CEC66 /* CodableResource.swift in Sources */,
 				B52240931FB3407900D0343F /* AzureDataExtensions.swift in Sources */,
 				93B7240B2064560F00984CA8 /* MSHttpHeader.swift in Sources */,
+				326E733620BC2AB8006D2DBD /* ADResponseMetadata.swift in Sources */,
+				329C7DD120BEF9E100A49453 /* ADResource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1250,10 +1624,10 @@
 				932832E62072CD9E0075ECC7 /* ExamplePermissionProviderTests.swift in Sources */,
 				B522405A1FB33DF100D0343F /* TriggerTests.swift in Sources */,
 				9317A81C2065763700338B63 /* ResourceOracleTests.swift in Sources */,
-				3276EA13208F3450003F6382 /* OfflineReadTests.swift in Sources */,
 				32AABD2220ACA05400F66DC6 /* MockReachabilityManager.swift in Sources */,
 				B522405C1FB33DF100D0343F /* PermissionTests.swift in Sources */,
 				B52240541FB33DF100D0343F /* StoredProcedureTests.swift in Sources */,
+				329C7DB420BEC28000A49453 /* OfflineReadTests.swift in Sources */,
 				B52240631FB33DF100D0343F /* AzureDataTests.swift in Sources */,
 				B52240561FB33DF100D0343F /* QueryTests.swift in Sources */,
 				3236FBDD209160F70002FB5F /* _AzureDataTests.swift in Sources */,
@@ -1552,6 +1926,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -1573,7 +1948,9 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1614,6 +1991,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -1627,7 +2005,9 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/AzureData/AzureData.xcodeproj/project.pbxproj
+++ b/AzureData/AzureData.xcodeproj/project.pbxproj
@@ -188,6 +188,18 @@
 		32D4D57920C2176200BF3154 /* ADDateEncoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D57720C2176200BF3154 /* ADDateEncoders.swift */; };
 		32D4D57A20C2176200BF3154 /* ADDateEncoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D57720C2176200BF3154 /* ADDateEncoders.swift */; };
 		32D4D57B20C2176200BF3154 /* ADDateEncoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D57720C2176200BF3154 /* ADDateEncoders.swift */; };
+		32D4D57D20C22B2300BF3154 /* ADConflictStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D57C20C22B2300BF3154 /* ADConflictStrategy.swift */; };
+		32D4D57E20C22B2300BF3154 /* ADConflictStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D57C20C22B2300BF3154 /* ADConflictStrategy.swift */; };
+		32D4D57F20C22B2300BF3154 /* ADConflictStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D57C20C22B2300BF3154 /* ADConflictStrategy.swift */; };
+		32D4D58020C22B2300BF3154 /* ADConflictStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D57C20C22B2300BF3154 /* ADConflictStrategy.swift */; };
+		32D4D58720C2860F00BF3154 /* ObjectiveCWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D58620C2860F00BF3154 /* ObjectiveCWrappers.swift */; };
+		32D4D58820C2860F00BF3154 /* ObjectiveCWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D58620C2860F00BF3154 /* ObjectiveCWrappers.swift */; };
+		32D4D58920C2860F00BF3154 /* ObjectiveCWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D58620C2860F00BF3154 /* ObjectiveCWrappers.swift */; };
+		32D4D58A20C2860F00BF3154 /* ObjectiveCWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D58620C2860F00BF3154 /* ObjectiveCWrappers.swift */; };
+		32D4D58C20C289B200BF3154 /* ADResourceSystemKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D58B20C289B200BF3154 /* ADResourceSystemKeys.swift */; };
+		32D4D58D20C289B200BF3154 /* ADResourceSystemKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D58B20C289B200BF3154 /* ADResourceSystemKeys.swift */; };
+		32D4D58E20C289B200BF3154 /* ADResourceSystemKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D58B20C289B200BF3154 /* ADResourceSystemKeys.swift */; };
+		32D4D58F20C289B200BF3154 /* ADResourceSystemKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D58B20C289B200BF3154 /* ADResourceSystemKeys.swift */; };
 		32EB2C1D209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
 		32EB2C1E209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
 		32EB2C1F209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
@@ -513,6 +525,9 @@
 		32AABD2620ACA83300F66DC6 /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
 		32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseMetadataTests.swift; sourceTree = "<group>"; };
 		32D4D57720C2176200BF3154 /* ADDateEncoders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADDateEncoders.swift; sourceTree = "<group>"; };
+		32D4D57C20C22B2300BF3154 /* ADConflictStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADConflictStrategy.swift; sourceTree = "<group>"; };
+		32D4D58620C2860F00BF3154 /* ObjectiveCWrappers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCWrappers.swift; sourceTree = "<group>"; };
+		32D4D58B20C289B200BF3154 /* ADResourceSystemKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADResourceSystemKeys.swift; sourceTree = "<group>"; };
 		32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceWriteOperation.swift; sourceTree = "<group>"; };
 		32FB702720BD5444009A35D9 /* ADPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADPermission.swift; sourceTree = "<group>"; };
 		32FB703120BD8070009A35D9 /* ADCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADCodable.swift; sourceTree = "<group>"; };
@@ -682,15 +697,18 @@
 			isa = PBXGroup;
 			children = (
 				326E731720BC2041006D2DBD /* ADAzureData.swift */,
+				32D4D57C20C22B2300BF3154 /* ADConflictStrategy.swift */,
 				32D4D57720C2176200BF3154 /* ADDateEncoders.swift */,
 				326E732120BC22EE006D2DBD /* ADPermissionProvider.swift */,
 				326E732620BC2339006D2DBD /* ADPermissionProviderConfiguration.swift */,
 				329C7DAE20BEB3EE00A49453 /* ADQuery.swift */,
+				32D4D58B20C289B200BF3154 /* ADResourceSystemKeys.swift */,
 				326E732B20BC23BE006D2DBD /* ADResourceType.swift */,
 				326E733020BC28B4006D2DBD /* ADResponse.swift */,
 				329C7DDA20BF08DF00A49453 /* ADSupportsPermissionToken.swift */,
 				326E734E20BC9D07006D2DBD /* ObjectiveCBridgeable.swift */,
 				3257CC5420C1486A004E51FF /* ObjectiveCUtilities.swift */,
+				32D4D58620C2860F00BF3154 /* ObjectiveCWrappers.swift */,
 				329C7DDF20BF0CED00A49453 /* SwiftWrappers.swift */,
 			);
 			path = "Objective-C";
@@ -1199,12 +1217,14 @@
 				329C7DCD20BEF15D00A49453 /* ADUser.swift in Sources */,
 				32A77CEB20C0570E00846397 /* ADIndex.swift in Sources */,
 				329C7DD720BEFDF600A49453 /* ADOffer.swift in Sources */,
+				32D4D57E20C22B2300BF3154 /* ADConflictStrategy.swift in Sources */,
 				B5B6AC2A1FBA84C400B93106 /* CodableDictionary.swift in Sources */,
 				329C7DBE20BEDCF200A49453 /* ADStoredProcedure.swift in Sources */,
 				B507D4F21FBB722000B2D18D /* Conflict.swift in Sources */,
 				329AA647209CEF470007A955 /* ResourceSystemProperties.swift in Sources */,
 				32FB702920BD5444009A35D9 /* ADPermission.swift in Sources */,
 				329C7DE120BF0CED00A49453 /* SwiftWrappers.swift in Sources */,
+				32D4D58820C2860F00BF3154 /* ObjectiveCWrappers.swift in Sources */,
 				B58361CE1FBA1439001CEC66 /* Attachment.swift in Sources */,
 				326E735020BC9D07006D2DBD /* ObjectiveCBridgeable.swift in Sources */,
 				326E732320BC22EE006D2DBD /* ADPermissionProvider.swift in Sources */,
@@ -1270,6 +1290,7 @@
 				329C7DC320BEE3B500A49453 /* ADUserDefinedFunction.swift in Sources */,
 				32799700209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */,
 				32A77CF520C0574A00846397 /* ADExcludedPath.swift in Sources */,
+				32D4D58D20C289B200BF3154 /* ADResourceSystemKeys.swift in Sources */,
 				B58361BA1FBA1385001CEC66 /* CodableResource.swift in Sources */,
 				B58361A71FB78F73001CEC66 /* DocumentClient.swift in Sources */,
 				93B7240C2064560F00984CA8 /* MSHttpHeader.swift in Sources */,
@@ -1324,12 +1345,14 @@
 				329C7DCE20BEF15D00A49453 /* ADUser.swift in Sources */,
 				32A77CEC20C0570E00846397 /* ADIndex.swift in Sources */,
 				329C7DD820BEFDF600A49453 /* ADOffer.swift in Sources */,
+				32D4D57F20C22B2300BF3154 /* ADConflictStrategy.swift in Sources */,
 				B5B6AC2B1FBA84C400B93106 /* CodableDictionary.swift in Sources */,
 				329C7DBF20BEDCF200A49453 /* ADStoredProcedure.swift in Sources */,
 				B507D4F31FBB722000B2D18D /* Conflict.swift in Sources */,
 				329AA648209CEF470007A955 /* ResourceSystemProperties.swift in Sources */,
 				32FB702A20BD5444009A35D9 /* ADPermission.swift in Sources */,
 				329C7DE220BF0CED00A49453 /* SwiftWrappers.swift in Sources */,
+				32D4D58920C2860F00BF3154 /* ObjectiveCWrappers.swift in Sources */,
 				B58361CF1FBA1439001CEC66 /* Attachment.swift in Sources */,
 				326E735120BC9D07006D2DBD /* ObjectiveCBridgeable.swift in Sources */,
 				326E732420BC22EE006D2DBD /* ADPermissionProvider.swift in Sources */,
@@ -1395,6 +1418,7 @@
 				329C7DC420BEE3B500A49453 /* ADUserDefinedFunction.swift in Sources */,
 				32799701209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */,
 				32A77CF620C0574A00846397 /* ADExcludedPath.swift in Sources */,
+				32D4D58E20C289B200BF3154 /* ADResourceSystemKeys.swift in Sources */,
 				B58361BB1FBA1385001CEC66 /* CodableResource.swift in Sources */,
 				B58361A61FB78F73001CEC66 /* DocumentClient.swift in Sources */,
 				93B7240D2064560F00984CA8 /* MSHttpHeader.swift in Sources */,
@@ -1449,12 +1473,14 @@
 				329C7DCF20BEF15D00A49453 /* ADUser.swift in Sources */,
 				32A77CED20C0570E00846397 /* ADIndex.swift in Sources */,
 				329C7DD920BEFDF600A49453 /* ADOffer.swift in Sources */,
+				32D4D58020C22B2300BF3154 /* ADConflictStrategy.swift in Sources */,
 				B5B6AC2C1FBA84C400B93106 /* CodableDictionary.swift in Sources */,
 				329C7DC020BEDCF200A49453 /* ADStoredProcedure.swift in Sources */,
 				B507D4F41FBB722000B2D18D /* Conflict.swift in Sources */,
 				329AA649209CEF470007A955 /* ResourceSystemProperties.swift in Sources */,
 				32FB702B20BD5444009A35D9 /* ADPermission.swift in Sources */,
 				329C7DE320BF0CED00A49453 /* SwiftWrappers.swift in Sources */,
+				32D4D58A20C2860F00BF3154 /* ObjectiveCWrappers.swift in Sources */,
 				B58361D01FBA1439001CEC66 /* Attachment.swift in Sources */,
 				326E735220BC9D07006D2DBD /* ObjectiveCBridgeable.swift in Sources */,
 				326E732520BC22EE006D2DBD /* ADPermissionProvider.swift in Sources */,
@@ -1520,6 +1546,7 @@
 				329C7DC520BEE3B500A49453 /* ADUserDefinedFunction.swift in Sources */,
 				32799702209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */,
 				32A77CF720C0574A00846397 /* ADExcludedPath.swift in Sources */,
+				32D4D58F20C289B200BF3154 /* ADResourceSystemKeys.swift in Sources */,
 				B58361BC1FBA1385001CEC66 /* CodableResource.swift in Sources */,
 				B58361A51FB78F71001CEC66 /* DocumentClient.swift in Sources */,
 				93B7240E2064560F00984CA8 /* MSHttpHeader.swift in Sources */,
@@ -1536,12 +1563,14 @@
 				329C7DCC20BEF15D00A49453 /* ADUser.swift in Sources */,
 				32A77CEA20C0570E00846397 /* ADIndex.swift in Sources */,
 				329C7DD620BEFDF600A49453 /* ADOffer.swift in Sources */,
+				32D4D57D20C22B2300BF3154 /* ADConflictStrategy.swift in Sources */,
 				B5B6AC291FBA84C400B93106 /* CodableDictionary.swift in Sources */,
 				329C7DBD20BEDCF200A49453 /* ADStoredProcedure.swift in Sources */,
 				B507D4F11FBB722000B2D18D /* Conflict.swift in Sources */,
 				329AA646209CEF470007A955 /* ResourceSystemProperties.swift in Sources */,
 				32FB702820BD5444009A35D9 /* ADPermission.swift in Sources */,
 				329C7DE020BF0CED00A49453 /* SwiftWrappers.swift in Sources */,
+				32D4D58720C2860F00BF3154 /* ObjectiveCWrappers.swift in Sources */,
 				B58361CD1FBA1439001CEC66 /* Attachment.swift in Sources */,
 				326E734F20BC9D07006D2DBD /* ObjectiveCBridgeable.swift in Sources */,
 				326E732220BC22EE006D2DBD /* ADPermissionProvider.swift in Sources */,
@@ -1607,6 +1636,7 @@
 				329C7DC220BEE3B500A49453 /* ADUserDefinedFunction.swift in Sources */,
 				327996FF209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */,
 				32A77CF420C0574A00846397 /* ADExcludedPath.swift in Sources */,
+				32D4D58C20C289B200BF3154 /* ADResourceSystemKeys.swift in Sources */,
 				B58361B91FBA1385001CEC66 /* CodableResource.swift in Sources */,
 				B52240931FB3407900D0343F /* AzureDataExtensions.swift in Sources */,
 				93B7240B2064560F00984CA8 /* MSHttpHeader.swift in Sources */,

--- a/AzureData/AzureData.xcodeproj/project.pbxproj
+++ b/AzureData/AzureData.xcodeproj/project.pbxproj
@@ -204,6 +204,10 @@
 		32D4D59220C2996900BF3154 /* ADAzureDataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D59020C2996900BF3154 /* ADAzureDataExtensions.swift */; };
 		32D4D59320C2996900BF3154 /* ADAzureDataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D59020C2996900BF3154 /* ADAzureDataExtensions.swift */; };
 		32D4D59420C2996900BF3154 /* ADAzureDataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D59020C2996900BF3154 /* ADAzureDataExtensions.swift */; };
+		32D4D59620C2C69800BF3154 /* ADOfferContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D59520C2C69800BF3154 /* ADOfferContent.swift */; };
+		32D4D59720C2C69800BF3154 /* ADOfferContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D59520C2C69800BF3154 /* ADOfferContent.swift */; };
+		32D4D59820C2C69800BF3154 /* ADOfferContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D59520C2C69800BF3154 /* ADOfferContent.swift */; };
+		32D4D59920C2C69800BF3154 /* ADOfferContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D59520C2C69800BF3154 /* ADOfferContent.swift */; };
 		32EB2C1D209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
 		32EB2C1E209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
 		32EB2C1F209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
@@ -533,6 +537,7 @@
 		32D4D58620C2860F00BF3154 /* ObjectiveCWrappers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCWrappers.swift; sourceTree = "<group>"; };
 		32D4D58B20C289B200BF3154 /* ADResourceSystemKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADResourceSystemKeys.swift; sourceTree = "<group>"; };
 		32D4D59020C2996900BF3154 /* ADAzureDataExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADAzureDataExtensions.swift; sourceTree = "<group>"; };
+		32D4D59520C2C69800BF3154 /* ADOfferContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADOfferContent.swift; sourceTree = "<group>"; };
 		32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceWriteOperation.swift; sourceTree = "<group>"; };
 		32FB702720BD5444009A35D9 /* ADPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADPermission.swift; sourceTree = "<group>"; };
 		32FB703120BD8070009A35D9 /* ADCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADCodable.swift; sourceTree = "<group>"; };
@@ -685,6 +690,7 @@
 				3257CCA020C1CCE4004E51FF /* ADDocument.m */,
 				32FB703620BD9B11009A35D9 /* ADDocument.swift */,
 				329C7DD520BEFDF600A49453 /* ADOffer.swift */,
+				32D4D59520C2C69800BF3154 /* ADOfferContent.swift */,
 				32FB702720BD5444009A35D9 /* ADPermission.swift */,
 				326E731C20BC2185006D2DBD /* ADPermissionMode.swift */,
 				326E733520BC2AB8006D2DBD /* ADResponseMetadata.swift */,
@@ -1219,6 +1225,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				32D4D59720C2C69800BF3154 /* ADOfferContent.swift in Sources */,
 				326E735520BCA3FC006D2DBD /* ADDocumentCollection.swift in Sources */,
 				329C7DCD20BEF15D00A49453 /* ADUser.swift in Sources */,
 				32A77CEB20C0570E00846397 /* ADIndex.swift in Sources */,
@@ -1348,6 +1355,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				32D4D59820C2C69800BF3154 /* ADOfferContent.swift in Sources */,
 				326E735620BCA3FC006D2DBD /* ADDocumentCollection.swift in Sources */,
 				329C7DCE20BEF15D00A49453 /* ADUser.swift in Sources */,
 				32A77CEC20C0570E00846397 /* ADIndex.swift in Sources */,
@@ -1477,6 +1485,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				32D4D59920C2C69800BF3154 /* ADOfferContent.swift in Sources */,
 				326E735720BCA3FC006D2DBD /* ADDocumentCollection.swift in Sources */,
 				329C7DCF20BEF15D00A49453 /* ADUser.swift in Sources */,
 				32A77CED20C0570E00846397 /* ADIndex.swift in Sources */,
@@ -1568,6 +1577,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				32D4D59620C2C69800BF3154 /* ADOfferContent.swift in Sources */,
 				326E735420BCA3FC006D2DBD /* ADDocumentCollection.swift in Sources */,
 				329C7DCC20BEF15D00A49453 /* ADUser.swift in Sources */,
 				32A77CEA20C0570E00846397 /* ADIndex.swift in Sources */,

--- a/AzureData/AzureData.xcodeproj/project.pbxproj
+++ b/AzureData/AzureData.xcodeproj/project.pbxproj
@@ -184,6 +184,10 @@
 		32AD4619207976AB00A0D02F /* ResponseMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */; };
 		32AD461A207976AB00A0D02F /* ResponseMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */; };
 		32AD461B207976AB00A0D02F /* ResponseMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */; };
+		32D4D57820C2176200BF3154 /* ADDateEncoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D57720C2176200BF3154 /* ADDateEncoders.swift */; };
+		32D4D57920C2176200BF3154 /* ADDateEncoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D57720C2176200BF3154 /* ADDateEncoders.swift */; };
+		32D4D57A20C2176200BF3154 /* ADDateEncoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D57720C2176200BF3154 /* ADDateEncoders.swift */; };
+		32D4D57B20C2176200BF3154 /* ADDateEncoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D4D57720C2176200BF3154 /* ADDateEncoders.swift */; };
 		32EB2C1D209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
 		32EB2C1E209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
 		32EB2C1F209C5DA700CEBB77 /* ResourceWriteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */; };
@@ -508,6 +512,7 @@
 		32AABD2120ACA05400F66DC6 /* MockReachabilityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockReachabilityManager.swift; sourceTree = "<group>"; };
 		32AABD2620ACA83300F66DC6 /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
 		32AD4618207976AB00A0D02F /* ResponseMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseMetadataTests.swift; sourceTree = "<group>"; };
+		32D4D57720C2176200BF3154 /* ADDateEncoders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADDateEncoders.swift; sourceTree = "<group>"; };
 		32EB2C1C209C5DA700CEBB77 /* ResourceWriteOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceWriteOperation.swift; sourceTree = "<group>"; };
 		32FB702720BD5444009A35D9 /* ADPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADPermission.swift; sourceTree = "<group>"; };
 		32FB703120BD8070009A35D9 /* ADCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADCodable.swift; sourceTree = "<group>"; };
@@ -677,6 +682,7 @@
 			isa = PBXGroup;
 			children = (
 				326E731720BC2041006D2DBD /* ADAzureData.swift */,
+				32D4D57720C2176200BF3154 /* ADDateEncoders.swift */,
 				326E732120BC22EE006D2DBD /* ADPermissionProvider.swift */,
 				326E732620BC2339006D2DBD /* ADPermissionProviderConfiguration.swift */,
 				329C7DAE20BEB3EE00A49453 /* ADQuery.swift */,
@@ -1214,6 +1220,7 @@
 				B58361B31FB78F7A001CEC66 /* Resources.swift in Sources */,
 				32A77CFA20C0576600846397 /* ADIndexingPolicy.swift in Sources */,
 				93F9ACCD1FC0CA4800AC240C /* DocumentClientError.swift in Sources */,
+				32D4D57920C2176200BF3154 /* ADDateEncoders.swift in Sources */,
 				32FB703820BD9B11009A35D9 /* ADDocument.swift in Sources */,
 				B58361D81FBA16F9001CEC66 /* Permission.swift in Sources */,
 				326E731E20BC2185006D2DBD /* ADPermissionMode.swift in Sources */,
@@ -1338,6 +1345,7 @@
 				B58361AE1FB78F7A001CEC66 /* Resources.swift in Sources */,
 				32A77CFB20C0576600846397 /* ADIndexingPolicy.swift in Sources */,
 				93F9ACCE1FC0CA4800AC240C /* DocumentClientError.swift in Sources */,
+				32D4D57A20C2176200BF3154 /* ADDateEncoders.swift in Sources */,
 				32FB703920BD9B11009A35D9 /* ADDocument.swift in Sources */,
 				B58361D91FBA16F9001CEC66 /* Permission.swift in Sources */,
 				326E731F20BC2185006D2DBD /* ADPermissionMode.swift in Sources */,
@@ -1462,6 +1470,7 @@
 				B58361A91FB78F78001CEC66 /* Resources.swift in Sources */,
 				32A77CFC20C0576600846397 /* ADIndexingPolicy.swift in Sources */,
 				93F9ACCF1FC0CA4800AC240C /* DocumentClientError.swift in Sources */,
+				32D4D57B20C2176200BF3154 /* ADDateEncoders.swift in Sources */,
 				32FB703A20BD9B11009A35D9 /* ADDocument.swift in Sources */,
 				B58361DA1FBA16F9001CEC66 /* Permission.swift in Sources */,
 				326E732020BC2185006D2DBD /* ADPermissionMode.swift in Sources */,
@@ -1548,6 +1557,7 @@
 				B58361D71FBA16F9001CEC66 /* Permission.swift in Sources */,
 				32A77CF920C0576600846397 /* ADIndexingPolicy.swift in Sources */,
 				93F9ACCC1FC0CA4800AC240C /* DocumentClientError.swift in Sources */,
+				32D4D57820C2176200BF3154 /* ADDateEncoders.swift in Sources */,
 				32FB703720BD9B11009A35D9 /* ADDocument.swift in Sources */,
 				B58361C31FBA13B0001CEC66 /* DocumentCollection.swift in Sources */,
 				326E731D20BC2185006D2DBD /* ADPermissionMode.swift in Sources */,

--- a/AzureData/Source/AzureData.h
+++ b/AzureData/Source/AzureData.h
@@ -10,4 +10,6 @@
 
 FOUNDATION_EXPORT double AzureDataVersionNumber;
 
+#import <AzureData/ADDocument.h>
+
 FOUNDATION_EXPORT const unsigned char AzureDataVersionString[];

--- a/AzureData/Source/AzureData.swift
+++ b/AzureData/Source/AzureData.swift
@@ -168,8 +168,8 @@ public func get (collectionWithId collectionId: String, inDatabase databaseId: S
     return DocumentClient.shared.get (collectionWithId: collectionId, inDatabase: databaseId, callback: callback)
 }
 
-public func get (collectionWithId collectionId: String, inDatabase database: Database, callback: @escaping (Response<DocumentCollection>) -> ()) {
-    return DocumentClient.shared.get (collectionWithId: collectionId, inDatabase: database, callback: callback)
+public func get (collectionWithId collectionId: String, in database: Database, callback: @escaping (Response<DocumentCollection>) -> ()) {
+    return DocumentClient.shared.get (collectionWithId: collectionId, in: database, callback: callback)
 }
 
 // delete
@@ -407,8 +407,8 @@ public func replace (userDefinedFunctionWithId functionId: String, andBody funct
     return DocumentClient.shared.replace (userDefinedFunctionWithId: functionId, andBody: function, inCollection: collectionId, inDatabase: databaseId, callback: callback)
 }
 
-public func replace (userDefinedFunctionWithId functionId: String, andBody function: String, from collection: DocumentCollection, callback: @escaping (Response<UserDefinedFunction>) -> ()) {
-    return DocumentClient.shared.replace (userDefinedFunctionWithId: functionId, andBody: function, from: collection, callback: callback)
+public func replace (userDefinedFunctionWithId functionId: String, andBody function: String, in collection: DocumentCollection, callback: @escaping (Response<UserDefinedFunction>) -> ()) {
+    return DocumentClient.shared.replace (userDefinedFunctionWithId: functionId, andBody: function, in: collection, callback: callback)
 }
 
 

--- a/AzureData/Source/AzureDataExtensions.swift
+++ b/AzureData/Source/AzureDataExtensions.swift
@@ -47,7 +47,7 @@ public extension Database {
     
     // get
     public func get (collectionWithId collectionId: String, callback: @escaping (Response<DocumentCollection>) -> ()) {
-        return DocumentClient.shared.get(collectionWithId: collectionId, inDatabase: self, callback: callback)
+        return DocumentClient.shared.get(collectionWithId: collectionId, in: self, callback: callback)
     }
     
     //delete
@@ -204,7 +204,7 @@ public extension DocumentCollection {
 
     // replace
     public func replace (userDefinedFunctionWithId id: String, andBody body: String, callback: @escaping (Response<UserDefinedFunction>) -> ()) {
-        return DocumentClient.shared.replace (userDefinedFunctionWithId: id, andBody: body, from: self, callback: callback)
+        return DocumentClient.shared.replace (userDefinedFunctionWithId: id, andBody: body, in: self, callback: callback)
     }
     
     

--- a/AzureData/Source/DocumentClient.swift
+++ b/AzureData/Source/DocumentClient.swift
@@ -201,7 +201,7 @@ class DocumentClient {
         return self.resource(at: .collection(databaseId: databaseId, id: collectionId), callback: callback)
     }
 
-    func get (collectionWithId collectionId: String, inDatabase database: Database, callback: @escaping (Response<DocumentCollection>) -> ()) {
+    func get (collectionWithId collectionId: String, in database: Database, callback: @escaping (Response<DocumentCollection>) -> ()) {
         return self.resource(at: .child(.collection, in: database, id: collectionId), callback: callback)
     }
 
@@ -445,7 +445,7 @@ class DocumentClient {
         return self.replace(UserDefinedFunction(functionId, body: function), at: .udf(databaseId: databaseId, collectionId: collectionId, id: functionId), callback: callback)
     }
     
-    func replace (userDefinedFunctionWithId functionId: String, andBody function: String, from collection: DocumentCollection, callback: @escaping (Response<UserDefinedFunction>) -> ()) {
+    func replace (userDefinedFunctionWithId functionId: String, andBody function: String, in collection: DocumentCollection, callback: @escaping (Response<UserDefinedFunction>) -> ()) {
         return self.replace(UserDefinedFunction(functionId, body: function), at: .child(.udf, in: collection, id: functionId), callback: callback)
     }
     

--- a/AzureData/Source/Objective-C/ADAzureData.swift
+++ b/AzureData/Source/Objective-C/ADAzureData.swift
@@ -43,21 +43,6 @@ public class ADAzureData: NSObject {
         AzureData.configure(withPlistNamed: name, withPermissionMode: mode.permissionMode)
     }
 
-    // MARK: - Conflict Strategy
-
-    @objc(registerConflictStrategy:forResourceType:)
-    public func register(strategy: ADConflictStrategy, for resourceType: ADResourceType) {
-        if let type = ResourceType(bridgedFromObjectiveC: resourceType) {
-            AzureData.register(strategy: ConflictStrategy(bridgedFromObjectiveC: strategy), for: type)
-        }
-    }
-
-    @objc(conflictStrategyForResourceType:)
-    public func conflictStrategy(for resourceType: ADResourceType) -> ADConflictStrategy? {
-        guard let type = ResourceType(bridgedFromObjectiveC: resourceType) else { return nil }
-        return DocumentClient.shared.conflictStrategies[type]?.bridgedToObjectiveC
-    }
-
     // MARK: - Offline Data
 
     @objc
@@ -80,7 +65,26 @@ public class ADAzureData: NSObject {
 
     // MARK: - Conflict Strategy
 
+    @objc(registerConflictStrategy:forResourceType:)
+    public func register(strategy: ADConflictStrategy, for resourceType: ADResourceType) {
+        if let type = ResourceType(bridgedFromObjectiveC: resourceType) {
+            AzureData.register(strategy: ConflictStrategy(bridgedFromObjectiveC: strategy), for: type)
+        }
+    }
+
+    @objc(conflictStrategyForResourceType:)
+    public func conflictStrategy(for resourceType: ADResourceType) -> ADConflictStrategy? {
+        guard let type = ResourceType(bridgedFromObjectiveC: resourceType) else { return nil }
+        return DocumentClient.shared.conflictStrategies[type]?.bridgedToObjectiveC
+    }
+
     // MARK: - Resource Encryption
+
+    @objc
+    public var resourceEncryptor: ResourceEncryptor? {
+        get { return AzureData.resourceEncryptor }
+        set { AzureData.resourceEncryptor = newValue }
+    }
 
     // MARK: - Databases
 

--- a/AzureData/Source/Objective-C/ADAzureData.swift
+++ b/AzureData/Source/Objective-C/ADAzureData.swift
@@ -63,28 +63,6 @@ public class ADAzureData: NSObject {
         AzureData.reset()
     }
 
-    // MARK: - Encoders & Decoders
-
-    public static var dateDecoder: ((Decoder) throws -> Date)? {
-        get { return AzureData.dateDecoder }
-        set { AzureData.dateDecoder = newValue }
-    }
-
-    public static var dateEncoder: ((Date, Encoder) throws -> Void)? {
-        get { return AzureData.dateEncoder }
-        set { AzureData.dateEncoder = newValue }
-    }
-
-    public static var jsonEncoder: JSONEncoder {
-        get { return AzureData.jsonEncoder }
-        set { AzureData.jsonEncoder = newValue }
-    }
-
-    public static var jsonDecoder: JSONDecoder {
-        get { return AzureData.jsonDecoder }
-        set { AzureData.jsonDecoder = newValue }
-    }
-
     // MARK: - Conflict Strategy
 
     // MARK: - Resource Encryption

--- a/AzureData/Source/Objective-C/ADAzureData.swift
+++ b/AzureData/Source/Objective-C/ADAzureData.swift
@@ -107,8 +107,8 @@ public class ADAzureData: NSObject {
 
     // get
     @objc(getDatabaseWithId:completion:)
-    public static func get(databaseWithId databaseId: String, callback: @escaping (ADResponse) -> Void) {
-        AzureData.get(databaseWithId: databaseId) { callback($0.bridgeToObjectiveC()) }
+    public static func get(databaseWithId databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(databaseWithId: databaseId) { completion($0.bridgeToObjectiveC()) }
     }
 
     // delete
@@ -137,18 +137,18 @@ public class ADAzureData: NSObject {
     }
 
     @objc(getCollectionsInDatabaseWithId:withMaxPerPage:completion:)
-    public static func get(collectionsIn databaseId: String, maxPerPage: Int, callback: @escaping (ADResponse) -> Void) {
-        AzureData.get(collectionsIn: databaseId, maxPerPage: maxPerPage) { callback($0.bridgeToObjectiveC()) }
+    public static func get(collectionsIn databaseId: String, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(collectionsIn: databaseId, maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
     }
 
     @objc(getCollectionsInDatabase:completion:)
-    public static func get(collectionsIn database: ADDatabase, callback: @escaping (ADResponse) -> Void) {
-        AzureData.get(collectionsIn: database.id, maxPerPage: nil) { callback($0.bridgeToObjectiveC()) }
+    public static func get(collectionsIn database: ADDatabase, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(collectionsIn: database.id, maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
     }
 
     @objc(getCollectionsInDatabase:withMaxPerPage:completion:)
-    public static func get(collectionsIn database: ADDatabase, maxPerPage: Int, callback: @escaping (ADResponse) -> Void) {
-        AzureData.get(collectionsIn: database.id, maxPerPage: maxPerPage) { callback($0.bridgeToObjectiveC()) }
+    public static func get(collectionsIn database: ADDatabase, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(collectionsIn: database.id, maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
     }
 
     // get
@@ -158,14 +158,19 @@ public class ADAzureData: NSObject {
     }
 
     @objc(getCollectionWithId:inDatabase:completion:)
-    public static func get(collectionWithId collectionId: String, in database: ADDatabase, callback: @escaping (ADResponse) -> Void) {
-        AzureData.get(collectionWithId: collectionId, inDatabase: database.id) { callback($0.bridgeToObjectiveC()) }
+    public static func get(collectionWithId collectionId: String, in database: ADDatabase, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(collectionWithId: collectionId, inDatabase: database.id) { completion($0.bridgeToObjectiveC()) }
     }
 
     // delete
     @objc(deleteCollectionWithId:fromDatabaseWithId:completion:)
     public static func delete(collectionWithId collectionId: String, fromDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
         AzureData.delete(collectionWithId: collectionId, fromDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(deleteCollectionWithId:from:completion:)
+    public static func delete(collectionWithId collectionId: String, from database: ADDatabase, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(collectionWithId: collectionId, from: Database(unconditionallyBridgedFromObjectiveC: database)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // replace
@@ -382,8 +387,8 @@ public class ADAzureData: NSObject {
     }
 
     @objc(replaceAttachmentWithId:contentType:name:withMedia:onDocument:completion:)
-    public static func replace (attachmentWithId attachmentId: String, contentType: String, name mediaName: String, with media: Data, on document: ADDocument, callback: @escaping (ADResponse) -> Void) {
-        AzureData.replace(attachmentWithId: attachmentId, contentType: contentType, name: mediaName, with: media, on: document.dictionaryDocument) { callback($0.bridgeToObjectiveC()) }
+    public static func replace (attachmentWithId attachmentId: String, contentType: String, name mediaName: String, with media: Data, on document: ADDocument, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(attachmentWithId: attachmentId, contentType: contentType, name: mediaName, with: media, on: document.dictionaryDocument) { completion($0.bridgeToObjectiveC()) }
     }
 
     // MARK: - Stored Procedures
@@ -422,8 +427,8 @@ public class ADAzureData: NSObject {
 
     // delete
     @objc(deleteStoredProcedureWithId:fromCollectionWithId:inDatabaseWithId:completion:)
-    public static func delete(storedProcedureWithId storedProcedureId: String, fromCollection collectionId: String, inDatabase databaseId: String, callback: @escaping (ADResponse) -> Void) {
-        AzureData.delete(storedProcedureWithId: storedProcedureId, fromCollection: collectionId, inDatabase: databaseId) { callback($0.bridgeToObjectiveC()) }
+    public static func delete(storedProcedureWithId storedProcedureId: String, fromCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(storedProcedureWithId: storedProcedureId, fromCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
     }
 
     @objc(deleteStoredProcedureWithId:fromCollection:completion:)
@@ -510,8 +515,8 @@ public class ADAzureData: NSObject {
     }
 
     @objc(replaceUserDefinedFunctionWithId:andBody:fromCollection:completion:)
-    public static func replace(userDefinedFunctionWithId functionId: String, andBody function: String, from collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.replace(userDefinedFunctionWithId: functionId, andBody: function, from: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+    public static func replace(userDefinedFunctionWithId functionId: String, andBody function: String, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(userDefinedFunctionWithId: functionId, andBody: function, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // MARK: - Triggers
@@ -694,12 +699,12 @@ public class ADAzureData: NSObject {
     }
 
     // replace
-    @objc(replacePermissionWithId:andMode:inResource:forUserWithId:inDatabaseWithId:completion:)
+    @objc(replacePermissionWithId:mode:inResource:forUserWithId:inDatabaseWithId:completion:)
     public static func replace(permissionWithId permissionId: String, mode: ADPermissionMode, in resource: ADResource & ADSupportsPermissionToken, forUser userId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
         AzureData.replace(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceSwiftWrapper(resource), forUser: userId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
     }
 
-    @objc(replacePermissionWithId:andMode:inResource:forUser:completion:)
+    @objc(replacePermissionWithId:mode:inResource:forUser:completion:)
     public static func replace(permissionWithId permissionId: String, mode: ADPermissionMode, in resource: ADResource & ADSupportsPermissionToken, for user: ADUser, completion: @escaping (ADResponse) -> Void) {
         AzureData.replace(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceSwiftWrapper(resource), for: User(unconditionallyBridgedFromObjectiveC: user)) { completion($0.bridgeToObjectiveC()) }
     }

--- a/AzureData/Source/Objective-C/ADAzureData.swift
+++ b/AzureData/Source/Objective-C/ADAzureData.swift
@@ -1,0 +1,750 @@
+//
+//  ADAzureData.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADAzureData)
+public class ADAzureData: NSObject {
+
+    // MARK: - Configuration
+
+    @objc
+    public static func isConfigured() -> Bool {
+        return AzureData.isConfigured()
+    }
+
+    @objc(configureForAccountNamed:withMasterKey:andPermissionMode:)
+    public static func configure(forAccountNamed name: String, withMasterKey key: String, withPermissionMode mode: ADPermissionMode) {
+        AzureData.configure(forAccountNamed: name, withMasterKey: key, withPermissionMode: mode.permissionMode)
+    }
+
+    @objc(configureForAccountAt:withMasterKey:andPermissionMode:)
+    public static func configure(forAccountAt url: URL, withMasterKey key: String, withPermissionMode mode: ADPermissionMode) {
+        AzureData.configure(forAccountAt: url, withMasterKey: key, withPermissionMode: mode.permissionMode)
+    }
+
+    @objc(configureForAccountNamed:withPermissionProvider:)
+    public static func configure(forAccountNamed name: String, withPermissionProvider permissionProvider: ADPermissionProvider) {
+        AzureData.configure(forAccountNamed: name, withPermissionProvider: ADPermissionProviderWrapper(permissionProvider))
+    }
+
+    @objc(configureForAccountAt:withPermissionProvider:)
+    public static func configure(forAccountAt url: URL, withPermissionProvider permissionProvider: ADPermissionProvider) {
+        AzureData.configure(forAccountAt: url, withPermissionProvider: ADPermissionProviderWrapper(permissionProvider))
+    }
+
+    @objc(configureWithPlistNamed:andPermissionMode:)
+    public static func configure(withPlistNamed name: String? = nil, withPermissionMode mode: ADPermissionMode) {
+        AzureData.configure(withPlistNamed: name, withPermissionMode: mode.permissionMode)
+    }
+
+    // MARK: - Offline Data
+
+    @objc
+    public static var offlineDataEnabled: Bool {
+        get { return AzureData.offlineDataEnabled }
+        set { AzureData.offlineDataEnabled = newValue }
+    }
+
+    @objc(purgeOfflineData:)
+    public static func purgeOfflineData() throws {
+        try AzureData.purgeOfflineData()
+    }
+
+    // MARK: - Reset
+
+    @objc
+    public static func reset() {
+        AzureData.reset()
+    }
+
+    // MARK: - Encoders & Decoders
+
+    public static var dateDecoder: ((Decoder) throws -> Date)? {
+        get { return AzureData.dateDecoder }
+        set { AzureData.dateDecoder = newValue }
+    }
+
+    public static var dateEncoder: ((Date, Encoder) throws -> Void)? {
+        get { return AzureData.dateEncoder }
+        set { AzureData.dateEncoder = newValue }
+    }
+
+    public static var jsonEncoder: JSONEncoder {
+        get { return AzureData.jsonEncoder }
+        set { AzureData.jsonEncoder = newValue }
+    }
+
+    public static var jsonDecoder: JSONDecoder {
+        get { return AzureData.jsonDecoder }
+        set { AzureData.jsonDecoder = newValue }
+    }
+
+    // MARK: - Conflict Strategy
+
+    // MARK: - Resource Encryption
+
+    // MARK: - Databases
+
+    // create
+    @objc(createDatabaseWithId:completion:)
+    public static func create(databaseWithId databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.create(databaseWithId: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // list
+    @objc(databasesWithCompletion:)
+    public static func databases(completion: @escaping (ADResponse) -> Void) {
+        AzureData.databases(maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(databasesWithMaxPerPage:completion:)
+    public static func databases(maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.databases(maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // get
+    @objc(getDatabaseWithId:completion:)
+    public static func get(databaseWithId databaseId: String, callback: @escaping (ADResponse) -> Void) {
+        AzureData.get(databaseWithId: databaseId) { callback($0.bridgeToObjectiveC()) }
+    }
+
+    // delete
+    @objc(deleteDatabaseWithId:completion:)
+    public static func delete(databaseWithId databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(databaseWithId: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // MARK: - Collections
+
+    // create
+    @objc(createCollectionWithId:inDatabaseWithId:completion:)
+    public static func create(collectionWithId collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.create(collectionWithId: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(createCollectionWithId:inDatabase:completion:)
+    public static func create(collectionWithId collectionId: String, in database: ADDatabase, completion: @escaping (ADResponse) -> Void) {
+        AzureData.create(collectionWithId: collectionId, inDatabase: database.id) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // list
+    @objc(getCollectionsInDatabaseWithId:completion:)
+    public static func get(collectionsIn databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(collectionsIn: databaseId, maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getCollectionsInDatabaseWithId:withMaxPerPage:completion:)
+    public static func get(collectionsIn databaseId: String, maxPerPage: Int, callback: @escaping (ADResponse) -> Void) {
+        AzureData.get(collectionsIn: databaseId, maxPerPage: maxPerPage) { callback($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getCollectionsInDatabase:completion:)
+    public static func get(collectionsIn database: ADDatabase, callback: @escaping (ADResponse) -> Void) {
+        AzureData.get(collectionsIn: database.id, maxPerPage: nil) { callback($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getCollectionsInDatabase:withMaxPerPage:completion:)
+    public static func get(collectionsIn database: ADDatabase, maxPerPage: Int, callback: @escaping (ADResponse) -> Void) {
+        AzureData.get(collectionsIn: database.id, maxPerPage: maxPerPage) { callback($0.bridgeToObjectiveC()) }
+    }
+
+    // get
+    @objc(getCollectionWithId:inDatabaseWithId:completion:)
+    public static func get(collectionWithId collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(collectionWithId: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getCollectionWithId:inDatabase:completion:)
+    public static func get(collectionWithId collectionId: String, in database: ADDatabase, callback: @escaping (ADResponse) -> Void) {
+        AzureData.get(collectionWithId: collectionId, inDatabase: database.id) { callback($0.bridgeToObjectiveC()) }
+    }
+
+    // delete
+    @objc(deleteCollectionWithId:fromDatabaseWithId:completion:)
+    public static func delete(collectionWithId collectionId: String, fromDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(collectionWithId: collectionId, fromDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // replace
+    @objc(replaceCollectionWithId:inDatabaseWithId:usingPolicy:completion:)
+    public static func replace(collectionWithId collectionId: String, inDatabase databaseId: String, usingPolicy policy: ADIndexingPolicy, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(collectionWithId: collectionId, inDatabase: databaseId, usingPolicy: DocumentCollection.IndexingPolicy(unconditionallyBridgedFromObjectiveC: policy)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // MARK: - Documents
+
+    // create or replace
+    @objc(createDocument:inCollectionWithId:inDatabaseWithId:completion:)
+    public static func create(document: ADDocument, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.create(document.dictionaryDocument, inCollection: collectionId, inDatabase: databaseId) {
+            let documentType = type(of: document)
+            completion($0.bridgeToObjectiveC(withDocumentType: documentType))
+        }
+    }
+
+    @objc(createDocument:inCollection:completion:)
+    public static func create(document: ADDocument, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.create(document.dictionaryDocument, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) {
+            let documentType = type(of: document)
+            completion($0.bridgeToObjectiveC(withDocumentType: documentType))
+        }
+    }
+
+    @objc(createOrReplaceDocument:inCollectionWithId:inDatabaseWithId:completion:)
+    public static func createOrReplace(document: ADDocument, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.createOrReplace(document.dictionaryDocument, inCollection: collectionId, inDatabase: databaseId) {
+            let documentType = type(of: document)
+            completion($0.bridgeToObjectiveC(withDocumentType: documentType))
+        }
+    }
+
+    @objc(createOrReplaceDocument:inCollection:completion:)
+    public static func createOrReplace(document: ADDocument, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.createOrReplace(document.dictionaryDocument, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) {
+            let documentType = type(of: document)
+            completion($0.bridgeToObjectiveC(withDocumentType: documentType))
+        }
+    }
+
+    // list
+    @objc(getDocumentsAs:inCollectionWithId:inDatabaseWithId:completion:)
+    public static func get(documentsAs documentType: ADDocument.Type, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(documentsAs: DictionaryDocument.self, inCollection: collectionId, inDatabase: databaseId, maxPerPage: nil) {
+            completion($0.bridgeToObjectiveC(withDocumentType: documentType))
+        }
+    }
+
+    @objc(getDocumentsAs:inCollectionWithId:inDatabaseWithId:withMaxPerPage:completion:)
+    public static func get(documentsAs documentType: ADDocument.Type, inCollection collectionId: String, inDatabase databaseId: String, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(documentsAs: DictionaryDocument.self, inCollection: collectionId, inDatabase: databaseId, maxPerPage: maxPerPage) {
+            completion($0.bridgeToObjectiveC(withDocumentType: documentType))
+        }
+    }
+
+    @objc(getDocumentsAs:inCollection:completion:)
+    public static func get(documentsAs documentType: ADDocument.Type, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(documentsAs: DictionaryDocument.self, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), maxPerPage: nil) {
+            completion($0.bridgeToObjectiveC(withDocumentType: documentType))
+        }
+    }
+
+    @objc(getDocumentsAs:inCollection:withMaxPerPage:completion:)
+    public static func get(documentsAs documentType: ADDocument.Type, in collection: ADDocumentCollection, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(documentsAs: DictionaryDocument.self, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), maxPerPage: maxPerPage) {
+            completion($0.bridgeToObjectiveC(withDocumentType: documentType))
+        }
+    }
+
+    // get
+    @objc(getDocumentWithId:as:inCollectionWithId:inDatabaseWithId:completion:)
+    public static func get(documentWithId documentId: String, as documentType: ADDocument.Type, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(documentWithId: documentId, as: DictionaryDocument.self, inCollection: collectionId, inDatabase: databaseId) {
+            completion($0.bridgeToObjectiveC(withDocumentType: documentType))
+        }
+    }
+
+    @objc(getDocumentWithId:as:inCollection:completion:)
+    public static func get(documentWithId documentId: String, as documentType: ADDocument.Type, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(documentWithId: documentId, as: DictionaryDocument.self, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) {
+            completion($0.bridgeToObjectiveC(withDocumentType: documentType))
+        }
+    }
+
+    // delete
+    @objc(deleteDocumentWithId:fromCollectionWithId:inDatabaseWithId:completion:)
+    public static func delete(documentWithId documentId: String, fromCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(documentWithId: documentId, fromCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(deleteDocumentWithId:fromCollection:completion:)
+    public static func delete(documentWithId documentId: String, from collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(documentWithId: documentId, from: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // replace
+    @objc(replaceDocument:inCollectionWithId:inDatabaseWithId:completion:)
+    public static func replace(document: ADDocument, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(document.dictionaryDocument, inCollection: collectionId, inDatabase: databaseId) {
+            let documentType = type(of: document)
+            completion($0.bridgeToObjectiveC(withDocumentType: documentType))
+        }
+    }
+
+    @objc(replaceDocument:inCollection:completion:)
+    public static func replace(document: ADDocument, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(document.dictionaryDocument, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) {
+            let documentType = type(of: document)
+            completion($0.bridgeToObjectiveC(withDocumentType: documentType))
+        }
+    }
+
+    // query
+    @objc(queryInCollectionWithId:documentsAs:inDatabaseId:withQuery:completion:)
+    public static func query(documentsIn collectionId: String, as documentType: ADDocument.Type, inDatabase databaseId: String, with query: ADQuery, completion: @escaping (ADResponse) -> Void) {
+        AzureData.query(documentsIn: collectionId, as: DictionaryDocument.self, inDatabase: databaseId, with: query.query, maxPerPage: nil) {
+            completion($0.bridgeToObjectiveC(withDocumentType: documentType))
+        }
+    }
+
+    @objc(queryInCollectionWithId:documentsAs:inDatabaseWithId:withQuery:withMaxPerPage:completion:)
+    public static func query(documentsIn collectionId: String, as documentType: ADDocument.Type, inDatabase databaseId: String, with query: ADQuery, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.query(documentsIn: collectionId, as: DictionaryDocument.self, inDatabase: databaseId, with: query.query, maxPerPage: maxPerPage) {
+            completion($0.bridgeToObjectiveC(withDocumentType: documentType))
+        }
+    }
+
+    @objc(queryDocumentsInCollection:as:withQuery:completion:)
+    public static func query(documentsIn collection: ADDocumentCollection, as documentType: ADDocument.Type, with query: ADQuery, completion: @escaping (ADResponse) -> Void) {
+        AzureData.query(documentsIn: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), with: query.query, maxPerPage: nil) {
+            completion($0.bridgeToObjectiveC(withDocumentType: documentType))
+        }
+    }
+
+    @objc(queryDocumentsInCollection:as:withQuery:withMaxPerPage:completion:)
+    public static func query(documentsIn collection: ADDocumentCollection, as documentType: ADDocument.Type, with query: ADQuery, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.query(documentsIn: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), with: query.query, maxPerPage: maxPerPage) {
+            completion($0.bridgeToObjectiveC(withDocumentType: documentType))
+        }
+    }
+
+    // MARK: - Attachments
+
+    @objc(createAttachmentWithId:contentType:andMediaUrl:onDocumentWithId:inCollectionId:inDatabaseId:completion:)
+    public static func create(attachmentWithId attachmentId: String, contentType: String, andMediaUrl mediaUrl: URL, onDocument documentId: String, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.create(attachmentWithId: attachmentId, contentType: contentType, andMediaUrl: mediaUrl, onDocument: documentId, inCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(createAttachmentWithId:contentType:name:andMedia:onDocumentWithId:inCollectionWithId:inDatabaseId:completion:)
+    public static func create(attachmentWithId attachmentId: String, contentType: String, name mediaName: String, with media: Data, onDocument documentId: String, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.create(attachmentWithId: attachmentId, contentType: contentType, name: mediaName, with: media, onDocument: documentId, inCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(createAttachmentWithId:contentType:andMediaUrl:onDocument:completion:)
+    public static func create(attachmentWithId attachmentId: String, contentType: String, andMediaUrl mediaUrl: URL, on document: ADDocument, completion: @escaping (ADResponse) -> Void) {
+        AzureData.create(attachmentWithId: attachmentId, contentType: contentType, andMediaUrl: mediaUrl, on: document.dictionaryDocument) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(createAttachmentWithId:contentType:name:andMedia:onDocument:completion:)
+    public static func create(attachmentWithId attachmentId: String, contentType: String, name mediaName: String, with media: Data, on document: ADDocument, completion: @escaping (ADResponse) -> Void) {
+        AzureData.create(attachmentWithId: attachmentId, contentType: contentType, name: mediaName, with: media, on: document.dictionaryDocument) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // list
+    @objc(getAttachmentsOnDocumentWithId:inCollectionWithId:inDatabaseWithId:completion:)
+    public static func get(attachmentsOn documentId: String, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(attachmentsOn: documentId, inCollection: collectionId, inDatabase: databaseId, maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getAttachmentsOnDocumentWithId:inCollectionWithId:inDatabaseWithId:withMaxPerPage:completion:)
+    public static func get(attachmentsOn documentId: String, inCollection collectionId: String, inDatabase databaseId: String, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(attachmentsOn: documentId, inCollection: collectionId, inDatabase: databaseId, maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getAttachmentsOnDocument:completion:)
+    public static func get(attachmentsOn document: ADDocument, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(attachmentsOn: document.dictionaryDocument, maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+    }
+
+
+    @objc(getAttachmentsOnDocument:withMaxPerPage:completion:)
+    public static func get(attachmentsOn document: ADDocument, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(attachmentsOn: document.dictionaryDocument, maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // delete
+    @objc(deleteAttachmentWithId:fromDocumentWithId:inCollectionWithId:inDatabaseWithId:completion:)
+    public func delete(attachmentWithId attachmentId: String, fromDocument documentId: String, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(attachmentWithId: attachmentId, fromDocument: documentId, inCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(deleteAttachmentWithId:fromDocument:completion:)
+    public static func delete(attachmentWithId attachmentId: String, from document: ADDocument, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(attachmentWithId: attachmentId, from: document.dictionaryDocument) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // replace
+    @objc(replaceAttachmentWithId:contentType:andMediaUrl:onDocumentWithId:inCollectionWithId:inDatabaseId:completion:)
+    public static func replace(attachmentWithId attachmentId: String, contentType: String, andMediaUrl mediaUrl: URL, onDocument documentId: String, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(attachmentWithId: attachmentId, contentType: contentType, andMediaUrl: mediaUrl, onDocument: documentId, inCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(replaceAttachmentWithId:contentType:name:withMedia:onDocumentWithId:inCollectionWithId:inDatabaseId:completion:)
+    public static func replace(attachmentWithId attachmentId: String, contentType: String, name mediaName: String, with media: Data, onDocument documentId: String, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(attachmentWithId: attachmentId, contentType: contentType, name: mediaName, with: media, onDocument: documentId, inCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(replaceAttachmentWithId:contentType:andMediaUrl:onDocument:completion:)
+    public static func replace(attachmentWithId attachmentId: String, contentType: String, andMediaUrl mediaUrl: URL, on document: ADDocument, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(attachmentWithId: attachmentId, contentType: contentType, andMediaUrl: mediaUrl, on: document.dictionaryDocument) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(replaceAttachmentWithId:contentType:name:withMedia:onDocument:completion:)
+    public static func replace (attachmentWithId attachmentId: String, contentType: String, name mediaName: String, with media: Data, on document: ADDocument, callback: @escaping (ADResponse) -> Void) {
+        AzureData.replace(attachmentWithId: attachmentId, contentType: contentType, name: mediaName, with: media, on: document.dictionaryDocument) { callback($0.bridgeToObjectiveC()) }
+    }
+
+    // MARK: - Stored Procedures
+
+    // create
+    @objc(createStoredProcedureWithId:andBody:inCollectionWithId:inDatabaseWithId:completion:)
+    public static func create(storedProcedureWithId storedProcedureId: String, andBody procedure: String, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.create(storedProcedureWithId: storedProcedureId, andBody: procedure, inCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(createStoredProcedureWithId:andBody:inCollection:completion:)
+    public static func create(storedProcedureWithId storedProcedureId: String, andBody procedure: String, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.create(storedProcedureWithId: storedProcedureId, andBody: procedure, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // list
+    @objc(getStoredProceduresInCollectionWithId:inDatabaseWithId:completion:)
+    public static func get(storedProceduresIn collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(storedProceduresIn: collectionId, inDatabase: databaseId, maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getStoredProceduresInCollectionWithId:inDatabaseWithId:withMaxPerPage:completion:)
+    public static func get(storedProceduresIn collectionId: String, inDatabase databaseId: String, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(storedProceduresIn: collectionId, inDatabase: databaseId, maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getStoredProceduresInCollection:completion:)
+    public static func get(storedProceduresIn collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(storedProceduresIn: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getStoredProceduresInCollection:withMaxPerPage:completion:)
+    public static func get(storedProceduresIn collection: ADDocumentCollection, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(storedProceduresIn: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // delete
+    @objc(deleteStoredProcedureWithId:fromCollectionWithId:inDatabaseWithId:completion:)
+    public static func delete(storedProcedureWithId storedProcedureId: String, fromCollection collectionId: String, inDatabase databaseId: String, callback: @escaping (ADResponse) -> Void) {
+        AzureData.delete(storedProcedureWithId: storedProcedureId, fromCollection: collectionId, inDatabase: databaseId) { callback($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(deleteStoredProcedureWithId:fromCollection:completion:)
+    public static func delete(storedProcedureWithId storedProcedureId: String, from collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(storedProcedureWithId: storedProcedureId, from: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC())}
+    }
+
+    // replace
+    @objc(replaceStoredProcedureWithId:andBody:inCollectionWithId:inDatabaseWithId:completion:)
+    public static func replace(storedProcedureWithId storedProcedureId: String, andBody procedure: String, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(storedProcedureWithId: storedProcedureId, andBody: procedure, inCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(replaceStoredProcedureWithId:andBody:inCollection:completion:)
+    public static func replace(storedProcedureWithId storedProcedureId: String, andBody procedure: String, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(storedProcedureWithId: storedProcedureId, andBody: procedure, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // execute
+    @objc(executeStoredProcedure:usingParameters:completion:)
+    public static func execute(storedProcedure: ADStoredProcedure, usingParameters parameters: [String]?, completion: @escaping (ADResponse) -> Void) {
+        AzureData.execute(StoredProcedure(unconditionallyBridgedFromObjectiveC: storedProcedure), usingParameters: parameters) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(executeStoredProcedureWithId:usingParameters:inCollectionWithId:inDatabaseWithId:completion:)
+    public static func execute(storedProcedureWithId storedProcedureId: String, usingParameters parameters: [String]?, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.execute(storedProcedureWithId: storedProcedureId, usingParameters: parameters, inCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(executeStoredProcedureWithId:usingParameters:inCollection:completion:)
+    public static func execute(storedProcedureWithId storedProcedureId: String, usingParameters parameters: [String]?, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.execute(storedProcedureWithId: storedProcedureId, usingParameters: parameters, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // MARK: - User Defined Functions
+
+    // create
+    @objc(createUserDefinedFunctionWithId:andBody:inCollectionWithId:inDatabaseWithId:completion:)
+    public static func create(userDefinedFunctionWithId functionId: String, andBody function: String, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.create(userDefinedFunctionWithId: functionId, andBody: function, inCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(createUserDefinedFunctionWithId:andBody:inCollection:completion:)
+    public static func create(userDefinedFunctionWithId functionId: String, andBody function: String, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.create(userDefinedFunctionWithId: functionId, andBody: function, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // list
+    @objc(getUsersDefinedFunctionsInCollectionWithId:inDatabaseWithId:completion:)
+    public static func get(userDefinedFunctionsIn collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(userDefinedFunctionsIn: collectionId, inDatabase: databaseId, maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getUsersDefinedFunctionsInCollectionWithId:inDatabaseWithId:withMaxPerPage:completion:)
+    public static func get(userDefinedFunctionsIn collectionId: String, inDatabase databaseId: String, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(userDefinedFunctionsIn: collectionId, inDatabase: databaseId, maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getUserDefinedFunctionsInCollection:completion:)
+    public static func get(userDefinedFunctionsIn collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(userDefinedFunctionsIn: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getUserDefinedFunctionsInCollection:withMaxPerPage:completion:)
+    public static func get(userDefinedFunctionsIn collection: ADDocumentCollection, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(userDefinedFunctionsIn: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // delete
+    @objc(deleteUserDefinedFunctionWithId:fromCollectionWithId:inDatabaseWithId:completion:)
+    public static func delete(userDefinedFunctionWithId functionId: String, fromCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(userDefinedFunctionWithId: functionId, fromCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(deleteUserDefinedFunctionWithId:fromCollection:completion:)
+    public static func delete(userDefinedFunctionWithId functionId: String, from collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(userDefinedFunctionWithId: functionId, from: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // replace
+    @objc(replaceUserDefinedFunctionWithId:andBody:inCollectionWithId:inDatabaseWithId:completion:)
+    public static func replace(userDefinedFunctionWithId functionId: String, andBody function: String, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(userDefinedFunctionWithId: functionId, andBody: function, inCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(replaceUserDefinedFunctionWithId:andBody:fromCollection:completion:)
+    public static func replace(userDefinedFunctionWithId functionId: String, andBody function: String, from collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(userDefinedFunctionWithId: functionId, andBody: function, from: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // MARK: - Triggers
+
+    // create
+    @objc(createTriggerWithId:operation:type:andBody:inCollectionWithId:inDatabaseWithId:completion:)
+    public static func create(triggerWithId triggerId: String, operation: ADTrigger.ObjCTriggerOperation, type: ADTrigger.ObjCTriggerType, andBody body: String, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> ()) {
+        AzureData.create(triggerWithId: triggerId, operation: Trigger.TriggerOperation(bridgedFromObjectiveC: operation), type: Trigger.TriggerType(bridgedFromObjectiveC: type), andBody: body, inCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(createTriggerWithId:operation:type:andBody:inCollection:completion:)
+    public static func create(triggerWithId triggerId: String, operation: ADTrigger.ObjCTriggerOperation, type: ADTrigger.ObjCTriggerType, andBody body: String, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> ()) {
+        AzureData.create(triggerWithId: triggerId, operation: Trigger.TriggerOperation(bridgedFromObjectiveC: operation), type: Trigger.TriggerType(bridgedFromObjectiveC: type), andBody: body, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // list
+    @objc(getTriggersInCollectionWithId:inDatabaseWithId:completion:)
+    public static func get(triggersIn collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(triggersIn: collectionId, inDatabase: databaseId, maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getTriggersInCollectionWithId:inDatabaseWithId:withMaxPerPage:completion:)
+    public static func get(triggersIn collectionId: String, inDatabase databaseId: String, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(triggersIn: collectionId, inDatabase: databaseId, maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getTriggersInCollection:completion:)
+    public static func get(triggersIn collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(triggersIn: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getTriggersInCollection:withMaxPerPage:completion:)
+    public static func get(triggersIn collection: ADDocumentCollection, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(triggersIn: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // delete
+    @objc(deleteTriggerWithId:fromCollectionWithId:inDatabaseWithId:completion:)
+    public static func delete(triggerWithId triggerId: String, fromCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(triggerWithId: triggerId, fromCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(deleteTriggerWithId:fromCollection:completion:)
+    public static func delete(triggerWithId triggerId: String, from collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(triggerWithId: triggerId, from: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // replace
+    @objc(replaceTriggerWithId:operation:type:andBody:inCollectionWithId:inDatabaseWithId:completion:)
+    public static func replace(triggerWithId triggerId: String, operation: ADTrigger.ObjCTriggerOperation, type: ADTrigger.ObjCTriggerType, andBody body: String, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(triggerWithId: triggerId, operation: Trigger.TriggerOperation(bridgedFromObjectiveC: operation), type: Trigger.TriggerType(bridgedFromObjectiveC: type), andBody: body, inCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(replaceTriggerWithId:operation:type:andBody:inCollection:completion:)
+    public static func replace(triggerWithId triggerId: String, operation: ADTrigger.ObjCTriggerOperation, type: ADTrigger.ObjCTriggerType, andBody body: String, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(triggerWithId: triggerId, operation: Trigger.TriggerOperation(bridgedFromObjectiveC: operation), type: Trigger.TriggerType(bridgedFromObjectiveC: type), andBody: body, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // MARK: - Users
+
+    // create
+    @objc(createUserWithId:inDatabaseWithId:completion:)
+    public static func create(userWithId userId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.create(userWithId: userId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(createUserWithId:inDatabase:completion:)
+    public static func create(userWithId userId: String, in database: ADDatabase, completion: @escaping (ADResponse) -> Void) {
+        AzureData.create(userWithId: userId, in: Database(unconditionallyBridgedFromObjectiveC: database)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // list
+    @objc(getUsersInDatabaseWithId:completion:)
+    public static func get(usersIn databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(usersIn: databaseId, maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getUsersInDatabaseWithId:withMaxPerPage:completion:)
+    public static func get(usersIn databaseId: String, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(usersIn: databaseId, maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getUsersInDatabase:completion:)
+    public static func get(usersIn database: ADDatabase, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(usersIn: Database(unconditionallyBridgedFromObjectiveC: database), maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getUsersInDatabase:withMaxPerPage:completion:)
+    public static func get(usersIn database: ADDatabase, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(usersIn: Database(unconditionallyBridgedFromObjectiveC: database), maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // get
+    @objc(getUserWithId:inDatabaseWithId:completion:)
+    public static func get(userWithId userId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(userWithId: userId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getUserWithId:inDatabase:completion:)
+    public static func get(userWithId userId: String, in database: ADDatabase, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(userWithId: userId, in: Database(unconditionallyBridgedFromObjectiveC: database)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // delete
+    @objc(deleteUserWithId:fromDatabaseWithId:completion:)
+    public static func delete(userWithId userId: String, fromDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(userWithId: userId, fromDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(deleteUserWithId:fromDatabase:completion:)
+    public static func delete(userWithId userId: String, from database: ADDatabase, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(userWithId: userId, from: Database(unconditionallyBridgedFromObjectiveC: database)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // replace
+    @objc(replaceUserWithId:withNewUserId:inDatabaseWithId:completion:)
+    public static func replace(userWithId userId: String, with newUserId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(userWithId: userId, with: newUserId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(replaceUserWithId:withNewUserId:inDatabase:completion:)
+    public static func replace(userWithId userId: String, with newUserId: String, in database: ADDatabase, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(userWithId: userId, with: newUserId, in: Database(unconditionallyBridgedFromObjectiveC: database)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // MARK: - Permissions
+
+    // create
+    @objc(createPermissionWithId:andMode:inResource:forUserWithId:inDatabaseWithId:completion:)
+    public static func create(permissionWithId permissionId: String, mode: ADPermissionMode, in resource: ADResource & ADSupportsPermissionToken, forUser userId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.create(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceWrapper(resource), forUser: userId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(createPermissionWithId:andMode:inResource:forUser:completion:)
+    public static func create(permissionWithId permissionId: String, mode: ADPermissionMode, in resource: ADResource & ADSupportsPermissionToken, for user: ADUser, completion: @escaping (ADResponse) -> Void) {
+        AzureData.create(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceWrapper(resource), for: User(unconditionallyBridgedFromObjectiveC: user)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // list
+    @objc(getPermissionsForUserWithId:inDatabaseWithId:completion:)
+    public static func get(permissionsFor userId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(permissionsFor: userId, inDatabase: databaseId, maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getPermissionsForUserWithId:inDatabaseWithId:withMaxPerPage:completion:)
+    public static func get(permissionsFor userId: String, inDatabase databaseId: String, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(permissionsFor: userId, inDatabase: databaseId, maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getPermissionsForUser:completion:)
+    public static func get(permissionsFor user: ADUser, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(permissionsFor: User(unconditionallyBridgedFromObjectiveC: user), maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getPermissionsForUser:withMaxPerPage:completion:)
+    public static func get(permissionsFor user: ADUser, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(permissionsFor: User(unconditionallyBridgedFromObjectiveC: user), maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // get
+    @objc(getPermissionWithId:forUserWithId:inDatabaseWithId:completion:)
+    public static func get(permissionWithId permissionId: String, forUser userId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(permissionWithId: permissionId, forUser: userId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getPermissionWithId:forUser:completion:)
+    public static func get(permissionWithId permissionId: String, for user: ADUser, completion: @escaping (ADResponse) -> Void) {
+        AzureData.get(permissionWithId: permissionId, for: User(unconditionallyBridgedFromObjectiveC: user)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // delete
+    @objc(deletePermissionWithId:fromUserWithId:inDatabaseWithId:completion:)
+    public static func delete(permissionWithId permissionId: String, fromUser userId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(permissionWithId: permissionId, fromUser: userId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(deletePermissionWithId:fromUser:completion:)
+    public static func delete(permissionWithId permissionId: String, from user: ADUser, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(permissionWithId: permissionId, from: User(unconditionallyBridgedFromObjectiveC: user)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // replace
+    @objc(replacePermissionWithId:andMode:inResource:forUserWithId:inDatabaseWithId:completion:)
+    public static func replace(permissionWithId permissionId: String, mode: ADPermissionMode, in resource: ADResource & ADSupportsPermissionToken, forUser userId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceWrapper(resource), forUser: userId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(replacePermissionWithId:andMode:inResource:forUser:completion:)
+    public static func replace(permissionWithId permissionId: String, mode: ADPermissionMode, in resource: ADResource & ADSupportsPermissionToken, for user: ADUser, completion: @escaping (ADResponse) -> Void) {
+        AzureData.replace(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceWrapper(resource), for: User(unconditionallyBridgedFromObjectiveC: user)) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // MARK: - Offers
+
+    // list
+    @objc
+    public static func offers(completion: @escaping (ADResponse) -> Void) {
+        AzureData.offers(maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(offersWithMaxPerPage:completion:)
+    public static func offers(maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        AzureData.offers(maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    @objc(getOfferWithId:completion:)
+    public static func get(offerWithId offerId: String, completion: @escaping (ADResponse) -> Void)  {
+        AzureData.get(offerWithId: offerId) { completion($0.bridgeToObjectiveC()) }
+    }
+
+    // MARK: - Resources
+
+    @objc(refreshResource:completion:)
+    public static func refresh(_ resource: ADResource, completion: @escaping (ADResponse) -> Void) {
+        do {
+            let data = try resource.encode().data()
+            let properties = ResourceSystemProperties(for: data)!
+            let resourceType = type(of: resource)
+
+            DocumentClient.shared.refresh(data, at: .resource(resource: properties)) { r in
+                let response: Response<ADResource> = r.map { (try resourceType.init(from: $0.dictionary()))! }
+                completion(ADResponse(erasingTypeOf: response))
+            }
+        } catch {
+            completion(ADResponse(Response(DocumentClientError(withError: error))))
+        }
+    }
+
+    @objc(deleteResource:completion:)
+    public static func delete(_ resource: ADResource, completion: @escaping (ADResponse) -> Void) {
+        AzureData.delete(ADResourceWrapper(resource)) { completion($0.bridgeToObjectiveC()) }
+    }
+}

--- a/AzureData/Source/Objective-C/ADAzureData.swift
+++ b/AzureData/Source/Objective-C/ADAzureData.swift
@@ -170,13 +170,13 @@ public class ADAzureData: NSObject {
 
     @objc(deleteCollectionWithId:from:completion:)
     public static func delete(collectionWithId collectionId: String, from database: ADDatabase, completion: @escaping (ADResponse) -> Void) {
-        AzureData.delete(collectionWithId: collectionId, from: Database(unconditionallyBridgedFromObjectiveC: database)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.delete(collectionWithId: collectionId, from: Database(bridgedFromObjectiveC: database)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // replace
     @objc(replaceCollectionWithId:inDatabaseWithId:usingPolicy:completion:)
     public static func replace(collectionWithId collectionId: String, inDatabase databaseId: String, usingPolicy policy: ADIndexingPolicy, completion: @escaping (ADResponse) -> Void) {
-        AzureData.replace(collectionWithId: collectionId, inDatabase: databaseId, usingPolicy: DocumentCollection.IndexingPolicy(unconditionallyBridgedFromObjectiveC: policy)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.replace(collectionWithId: collectionId, inDatabase: databaseId, usingPolicy: DocumentCollection.IndexingPolicy(bridgedFromObjectiveC: policy)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // MARK: - Documents
@@ -192,7 +192,7 @@ public class ADAzureData: NSObject {
 
     @objc(createDocument:inCollection:completion:)
     public static func create(document: ADDocument, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.create(document.dictionaryDocument, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) {
+        AzureData.create(document.dictionaryDocument, in: DocumentCollection(bridgedFromObjectiveC: collection)) {
             let documentType = type(of: document)
             completion($0.bridgeToObjectiveC(withDocumentType: documentType))
         }
@@ -208,7 +208,7 @@ public class ADAzureData: NSObject {
 
     @objc(createOrReplaceDocument:inCollection:completion:)
     public static func createOrReplace(document: ADDocument, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.createOrReplace(document.dictionaryDocument, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) {
+        AzureData.createOrReplace(document.dictionaryDocument, in: DocumentCollection(bridgedFromObjectiveC: collection)) {
             let documentType = type(of: document)
             completion($0.bridgeToObjectiveC(withDocumentType: documentType))
         }
@@ -231,14 +231,14 @@ public class ADAzureData: NSObject {
 
     @objc(getDocumentsAs:inCollection:completion:)
     public static func get(documentsAs documentType: ADDocument.Type, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.get(documentsAs: DictionaryDocument.self, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), maxPerPage: nil) {
+        AzureData.get(documentsAs: DictionaryDocument.self, in: DocumentCollection(bridgedFromObjectiveC: collection), maxPerPage: nil) {
             completion($0.bridgeToObjectiveC(withDocumentType: documentType))
         }
     }
 
     @objc(getDocumentsAs:inCollection:withMaxPerPage:completion:)
     public static func get(documentsAs documentType: ADDocument.Type, in collection: ADDocumentCollection, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
-        AzureData.get(documentsAs: DictionaryDocument.self, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), maxPerPage: maxPerPage) {
+        AzureData.get(documentsAs: DictionaryDocument.self, in: DocumentCollection(bridgedFromObjectiveC: collection), maxPerPage: maxPerPage) {
             completion($0.bridgeToObjectiveC(withDocumentType: documentType))
         }
     }
@@ -253,7 +253,7 @@ public class ADAzureData: NSObject {
 
     @objc(getDocumentWithId:as:inCollection:completion:)
     public static func get(documentWithId documentId: String, as documentType: ADDocument.Type, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.get(documentWithId: documentId, as: DictionaryDocument.self, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) {
+        AzureData.get(documentWithId: documentId, as: DictionaryDocument.self, in: DocumentCollection(bridgedFromObjectiveC: collection)) {
             completion($0.bridgeToObjectiveC(withDocumentType: documentType))
         }
     }
@@ -266,7 +266,7 @@ public class ADAzureData: NSObject {
 
     @objc(deleteDocumentWithId:fromCollection:completion:)
     public static func delete(documentWithId documentId: String, from collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.delete(documentWithId: documentId, from: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.delete(documentWithId: documentId, from: DocumentCollection(bridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // replace
@@ -280,7 +280,7 @@ public class ADAzureData: NSObject {
 
     @objc(replaceDocument:inCollection:completion:)
     public static func replace(document: ADDocument, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.replace(document.dictionaryDocument, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) {
+        AzureData.replace(document.dictionaryDocument, in: DocumentCollection(bridgedFromObjectiveC: collection)) {
             let documentType = type(of: document)
             completion($0.bridgeToObjectiveC(withDocumentType: documentType))
         }
@@ -303,14 +303,14 @@ public class ADAzureData: NSObject {
 
     @objc(queryDocumentsInCollection:as:withQuery:completion:)
     public static func query(documentsIn collection: ADDocumentCollection, as documentType: ADDocument.Type, with query: ADQuery, completion: @escaping (ADResponse) -> Void) {
-        AzureData.query(documentsIn: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), with: query.query, maxPerPage: nil) {
+        AzureData.query(documentsIn: DocumentCollection(bridgedFromObjectiveC: collection), with: query.query, maxPerPage: nil) {
             completion($0.bridgeToObjectiveC(withDocumentType: documentType))
         }
     }
 
     @objc(queryDocumentsInCollection:as:withQuery:withMaxPerPage:completion:)
     public static func query(documentsIn collection: ADDocumentCollection, as documentType: ADDocument.Type, with query: ADQuery, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
-        AzureData.query(documentsIn: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), with: query.query, maxPerPage: maxPerPage) {
+        AzureData.query(documentsIn: DocumentCollection(bridgedFromObjectiveC: collection), with: query.query, maxPerPage: maxPerPage) {
             completion($0.bridgeToObjectiveC(withDocumentType: documentType))
         }
     }
@@ -401,7 +401,7 @@ public class ADAzureData: NSObject {
 
     @objc(createStoredProcedureWithId:andBody:inCollection:completion:)
     public static func create(storedProcedureWithId storedProcedureId: String, andBody procedure: String, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.create(storedProcedureWithId: storedProcedureId, andBody: procedure, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.create(storedProcedureWithId: storedProcedureId, andBody: procedure, in: DocumentCollection(bridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // list
@@ -417,12 +417,12 @@ public class ADAzureData: NSObject {
 
     @objc(getStoredProceduresInCollection:completion:)
     public static func get(storedProceduresIn collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.get(storedProceduresIn: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+        AzureData.get(storedProceduresIn: DocumentCollection(bridgedFromObjectiveC: collection), maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
     }
 
     @objc(getStoredProceduresInCollection:withMaxPerPage:completion:)
     public static func get(storedProceduresIn collection: ADDocumentCollection, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
-        AzureData.get(storedProceduresIn: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+        AzureData.get(storedProceduresIn: DocumentCollection(bridgedFromObjectiveC: collection), maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
     }
 
     // delete
@@ -433,7 +433,7 @@ public class ADAzureData: NSObject {
 
     @objc(deleteStoredProcedureWithId:fromCollection:completion:)
     public static func delete(storedProcedureWithId storedProcedureId: String, from collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.delete(storedProcedureWithId: storedProcedureId, from: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC())}
+        AzureData.delete(storedProcedureWithId: storedProcedureId, from: DocumentCollection(bridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC())}
     }
 
     // replace
@@ -444,13 +444,13 @@ public class ADAzureData: NSObject {
 
     @objc(replaceStoredProcedureWithId:andBody:inCollection:completion:)
     public static func replace(storedProcedureWithId storedProcedureId: String, andBody procedure: String, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.replace(storedProcedureWithId: storedProcedureId, andBody: procedure, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.replace(storedProcedureWithId: storedProcedureId, andBody: procedure, in: DocumentCollection(bridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // execute
     @objc(executeStoredProcedure:usingParameters:completion:)
     public static func execute(storedProcedure: ADStoredProcedure, usingParameters parameters: [String]?, completion: @escaping (ADResponse) -> Void) {
-        AzureData.execute(StoredProcedure(unconditionallyBridgedFromObjectiveC: storedProcedure), usingParameters: parameters) { completion($0.bridgeToObjectiveC()) }
+        AzureData.execute(StoredProcedure(bridgedFromObjectiveC: storedProcedure), usingParameters: parameters) { completion($0.bridgeToObjectiveC()) }
     }
 
     @objc(executeStoredProcedureWithId:usingParameters:inCollectionWithId:inDatabaseWithId:completion:)
@@ -460,7 +460,7 @@ public class ADAzureData: NSObject {
 
     @objc(executeStoredProcedureWithId:usingParameters:inCollection:completion:)
     public static func execute(storedProcedureWithId storedProcedureId: String, usingParameters parameters: [String]?, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.execute(storedProcedureWithId: storedProcedureId, usingParameters: parameters, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.execute(storedProcedureWithId: storedProcedureId, usingParameters: parameters, in: DocumentCollection(bridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // MARK: - User Defined Functions
@@ -473,7 +473,7 @@ public class ADAzureData: NSObject {
 
     @objc(createUserDefinedFunctionWithId:andBody:inCollection:completion:)
     public static func create(userDefinedFunctionWithId functionId: String, andBody function: String, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.create(userDefinedFunctionWithId: functionId, andBody: function, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.create(userDefinedFunctionWithId: functionId, andBody: function, in: DocumentCollection(bridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // list
@@ -489,12 +489,12 @@ public class ADAzureData: NSObject {
 
     @objc(getUserDefinedFunctionsInCollection:completion:)
     public static func get(userDefinedFunctionsIn collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.get(userDefinedFunctionsIn: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+        AzureData.get(userDefinedFunctionsIn: DocumentCollection(bridgedFromObjectiveC: collection), maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
     }
 
     @objc(getUserDefinedFunctionsInCollection:withMaxPerPage:completion:)
     public static func get(userDefinedFunctionsIn collection: ADDocumentCollection, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
-        AzureData.get(userDefinedFunctionsIn: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+        AzureData.get(userDefinedFunctionsIn: DocumentCollection(bridgedFromObjectiveC: collection), maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
     }
 
     // delete
@@ -505,7 +505,7 @@ public class ADAzureData: NSObject {
 
     @objc(deleteUserDefinedFunctionWithId:fromCollection:completion:)
     public static func delete(userDefinedFunctionWithId functionId: String, from collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.delete(userDefinedFunctionWithId: functionId, from: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.delete(userDefinedFunctionWithId: functionId, from: DocumentCollection(bridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // replace
@@ -516,7 +516,7 @@ public class ADAzureData: NSObject {
 
     @objc(replaceUserDefinedFunctionWithId:andBody:fromCollection:completion:)
     public static func replace(userDefinedFunctionWithId functionId: String, andBody function: String, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.replace(userDefinedFunctionWithId: functionId, andBody: function, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.replace(userDefinedFunctionWithId: functionId, andBody: function, in: DocumentCollection(bridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // MARK: - Triggers
@@ -529,7 +529,7 @@ public class ADAzureData: NSObject {
 
     @objc(createTriggerWithId:operation:type:andBody:inCollection:completion:)
     public static func create(triggerWithId triggerId: String, operation: ADTrigger.ADTriggerOperation, type: ADTrigger.ADTriggerType, andBody body: String, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> ()) {
-        AzureData.create(triggerWithId: triggerId, operation: Trigger.TriggerOperation(bridgedFromObjectiveC: operation), type: Trigger.TriggerType(bridgedFromObjectiveC: type), andBody: body, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.create(triggerWithId: triggerId, operation: Trigger.TriggerOperation(bridgedFromObjectiveC: operation), type: Trigger.TriggerType(bridgedFromObjectiveC: type), andBody: body, in: DocumentCollection(bridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // list
@@ -545,12 +545,12 @@ public class ADAzureData: NSObject {
 
     @objc(getTriggersInCollection:completion:)
     public static func get(triggersIn collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.get(triggersIn: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+        AzureData.get(triggersIn: DocumentCollection(bridgedFromObjectiveC: collection), maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
     }
 
     @objc(getTriggersInCollection:withMaxPerPage:completion:)
     public static func get(triggersIn collection: ADDocumentCollection, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
-        AzureData.get(triggersIn: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection), maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+        AzureData.get(triggersIn: DocumentCollection(bridgedFromObjectiveC: collection), maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
     }
 
     // delete
@@ -561,7 +561,7 @@ public class ADAzureData: NSObject {
 
     @objc(deleteTriggerWithId:fromCollection:completion:)
     public static func delete(triggerWithId triggerId: String, from collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.delete(triggerWithId: triggerId, from: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.delete(triggerWithId: triggerId, from: DocumentCollection(bridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // replace
@@ -572,7 +572,7 @@ public class ADAzureData: NSObject {
 
     @objc(replaceTriggerWithId:operation:type:andBody:inCollection:completion:)
     public static func replace(triggerWithId triggerId: String, operation: ADTrigger.ADTriggerOperation, type: ADTrigger.ADTriggerType, andBody body: String, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
-        AzureData.replace(triggerWithId: triggerId, operation: Trigger.TriggerOperation(bridgedFromObjectiveC: operation), type: Trigger.TriggerType(bridgedFromObjectiveC: type), andBody: body, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.replace(triggerWithId: triggerId, operation: Trigger.TriggerOperation(bridgedFromObjectiveC: operation), type: Trigger.TriggerType(bridgedFromObjectiveC: type), andBody: body, in: DocumentCollection(bridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // MARK: - Users
@@ -585,7 +585,7 @@ public class ADAzureData: NSObject {
 
     @objc(createUserWithId:inDatabase:completion:)
     public static func create(userWithId userId: String, in database: ADDatabase, completion: @escaping (ADResponse) -> Void) {
-        AzureData.create(userWithId: userId, in: Database(unconditionallyBridgedFromObjectiveC: database)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.create(userWithId: userId, in: Database(bridgedFromObjectiveC: database)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // list
@@ -601,12 +601,12 @@ public class ADAzureData: NSObject {
 
     @objc(getUsersInDatabase:completion:)
     public static func get(usersIn database: ADDatabase, completion: @escaping (ADResponse) -> Void) {
-        AzureData.get(usersIn: Database(unconditionallyBridgedFromObjectiveC: database), maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+        AzureData.get(usersIn: Database(bridgedFromObjectiveC: database), maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
     }
 
     @objc(getUsersInDatabase:withMaxPerPage:completion:)
     public static func get(usersIn database: ADDatabase, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
-        AzureData.get(usersIn: Database(unconditionallyBridgedFromObjectiveC: database), maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+        AzureData.get(usersIn: Database(bridgedFromObjectiveC: database), maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
     }
 
     // get
@@ -617,7 +617,7 @@ public class ADAzureData: NSObject {
 
     @objc(getUserWithId:inDatabase:completion:)
     public static func get(userWithId userId: String, in database: ADDatabase, completion: @escaping (ADResponse) -> Void) {
-        AzureData.get(userWithId: userId, in: Database(unconditionallyBridgedFromObjectiveC: database)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.get(userWithId: userId, in: Database(bridgedFromObjectiveC: database)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // delete
@@ -628,7 +628,7 @@ public class ADAzureData: NSObject {
 
     @objc(deleteUserWithId:fromDatabase:completion:)
     public static func delete(userWithId userId: String, from database: ADDatabase, completion: @escaping (ADResponse) -> Void) {
-        AzureData.delete(userWithId: userId, from: Database(unconditionallyBridgedFromObjectiveC: database)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.delete(userWithId: userId, from: Database(bridgedFromObjectiveC: database)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // replace
@@ -639,7 +639,7 @@ public class ADAzureData: NSObject {
 
     @objc(replaceUserWithId:withNewUserId:inDatabase:completion:)
     public static func replace(userWithId userId: String, with newUserId: String, in database: ADDatabase, completion: @escaping (ADResponse) -> Void) {
-        AzureData.replace(userWithId: userId, with: newUserId, in: Database(unconditionallyBridgedFromObjectiveC: database)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.replace(userWithId: userId, with: newUserId, in: Database(bridgedFromObjectiveC: database)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // MARK: - Permissions
@@ -652,7 +652,7 @@ public class ADAzureData: NSObject {
 
     @objc(createPermissionWithId:andMode:inResource:forUser:completion:)
     public static func create(permissionWithId permissionId: String, mode: ADPermissionMode, in resource: ADResource & ADSupportsPermissionToken, for user: ADUser, completion: @escaping (ADResponse) -> Void) {
-        AzureData.create(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceSwiftWrapper(resource), for: User(unconditionallyBridgedFromObjectiveC: user)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.create(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceSwiftWrapper(resource), for: User(bridgedFromObjectiveC: user)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // list
@@ -668,12 +668,12 @@ public class ADAzureData: NSObject {
 
     @objc(getPermissionsForUser:completion:)
     public static func get(permissionsFor user: ADUser, completion: @escaping (ADResponse) -> Void) {
-        AzureData.get(permissionsFor: User(unconditionallyBridgedFromObjectiveC: user), maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
+        AzureData.get(permissionsFor: User(bridgedFromObjectiveC: user), maxPerPage: nil) { completion($0.bridgeToObjectiveC()) }
     }
 
     @objc(getPermissionsForUser:withMaxPerPage:completion:)
     public static func get(permissionsFor user: ADUser, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
-        AzureData.get(permissionsFor: User(unconditionallyBridgedFromObjectiveC: user), maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
+        AzureData.get(permissionsFor: User(bridgedFromObjectiveC: user), maxPerPage: maxPerPage) { completion($0.bridgeToObjectiveC()) }
     }
 
     // get
@@ -684,7 +684,7 @@ public class ADAzureData: NSObject {
 
     @objc(getPermissionWithId:forUser:completion:)
     public static func get(permissionWithId permissionId: String, for user: ADUser, completion: @escaping (ADResponse) -> Void) {
-        AzureData.get(permissionWithId: permissionId, for: User(unconditionallyBridgedFromObjectiveC: user)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.get(permissionWithId: permissionId, for: User(bridgedFromObjectiveC: user)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // delete
@@ -695,7 +695,7 @@ public class ADAzureData: NSObject {
 
     @objc(deletePermissionWithId:fromUser:completion:)
     public static func delete(permissionWithId permissionId: String, from user: ADUser, completion: @escaping (ADResponse) -> Void) {
-        AzureData.delete(permissionWithId: permissionId, from: User(unconditionallyBridgedFromObjectiveC: user)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.delete(permissionWithId: permissionId, from: User(bridgedFromObjectiveC: user)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // replace
@@ -706,7 +706,7 @@ public class ADAzureData: NSObject {
 
     @objc(replacePermissionWithId:mode:inResource:forUser:completion:)
     public static func replace(permissionWithId permissionId: String, mode: ADPermissionMode, in resource: ADResource & ADSupportsPermissionToken, for user: ADUser, completion: @escaping (ADResponse) -> Void) {
-        AzureData.replace(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceSwiftWrapper(resource), for: User(unconditionallyBridgedFromObjectiveC: user)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.replace(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceSwiftWrapper(resource), for: User(bridgedFromObjectiveC: user)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // MARK: - Offers

--- a/AzureData/Source/Objective-C/ADAzureData.swift
+++ b/AzureData/Source/Objective-C/ADAzureData.swift
@@ -43,6 +43,21 @@ public class ADAzureData: NSObject {
         AzureData.configure(withPlistNamed: name, withPermissionMode: mode.permissionMode)
     }
 
+    // MARK: - Conflict Strategy
+
+    @objc(registerConflictStrategy:forResourceType:)
+    public func register(strategy: ADConflictStrategy, for resourceType: ADResourceType) {
+        if let type = ResourceType(bridgedFromObjectiveC: resourceType) {
+            AzureData.register(strategy: ConflictStrategy(bridgedFromObjectiveC: strategy), for: type)
+        }
+    }
+
+    @objc(conflictStrategyForResourceType:)
+    public func conflictStrategy(for resourceType: ADResourceType) -> ADConflictStrategy? {
+        guard let type = ResourceType(bridgedFromObjectiveC: resourceType) else { return nil }
+        return DocumentClient.shared.conflictStrategies[type]?.bridgedToObjectiveC
+    }
+
     // MARK: - Offline Data
 
     @objc
@@ -499,12 +514,12 @@ public class ADAzureData: NSObject {
 
     // create
     @objc(createTriggerWithId:operation:type:andBody:inCollectionWithId:inDatabaseWithId:completion:)
-    public static func create(triggerWithId triggerId: String, operation: ADTrigger.ObjCTriggerOperation, type: ADTrigger.ObjCTriggerType, andBody body: String, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> ()) {
+    public static func create(triggerWithId triggerId: String, operation: ADTrigger.ADTriggerOperation, type: ADTrigger.ADTriggerType, andBody body: String, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> ()) {
         AzureData.create(triggerWithId: triggerId, operation: Trigger.TriggerOperation(bridgedFromObjectiveC: operation), type: Trigger.TriggerType(bridgedFromObjectiveC: type), andBody: body, inCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
     }
 
     @objc(createTriggerWithId:operation:type:andBody:inCollection:completion:)
-    public static func create(triggerWithId triggerId: String, operation: ADTrigger.ObjCTriggerOperation, type: ADTrigger.ObjCTriggerType, andBody body: String, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> ()) {
+    public static func create(triggerWithId triggerId: String, operation: ADTrigger.ADTriggerOperation, type: ADTrigger.ADTriggerType, andBody body: String, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> ()) {
         AzureData.create(triggerWithId: triggerId, operation: Trigger.TriggerOperation(bridgedFromObjectiveC: operation), type: Trigger.TriggerType(bridgedFromObjectiveC: type), andBody: body, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
     }
 
@@ -542,12 +557,12 @@ public class ADAzureData: NSObject {
 
     // replace
     @objc(replaceTriggerWithId:operation:type:andBody:inCollectionWithId:inDatabaseWithId:completion:)
-    public static func replace(triggerWithId triggerId: String, operation: ADTrigger.ObjCTriggerOperation, type: ADTrigger.ObjCTriggerType, andBody body: String, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
+    public static func replace(triggerWithId triggerId: String, operation: ADTrigger.ADTriggerOperation, type: ADTrigger.ADTriggerType, andBody body: String, inCollection collectionId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
         AzureData.replace(triggerWithId: triggerId, operation: Trigger.TriggerOperation(bridgedFromObjectiveC: operation), type: Trigger.TriggerType(bridgedFromObjectiveC: type), andBody: body, inCollection: collectionId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
     }
 
     @objc(replaceTriggerWithId:operation:type:andBody:inCollection:completion:)
-    public static func replace(triggerWithId triggerId: String, operation: ADTrigger.ObjCTriggerOperation, type: ADTrigger.ObjCTriggerType, andBody body: String, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
+    public static func replace(triggerWithId triggerId: String, operation: ADTrigger.ADTriggerOperation, type: ADTrigger.ADTriggerType, andBody body: String, in collection: ADDocumentCollection, completion: @escaping (ADResponse) -> Void) {
         AzureData.replace(triggerWithId: triggerId, operation: Trigger.TriggerOperation(bridgedFromObjectiveC: operation), type: Trigger.TriggerType(bridgedFromObjectiveC: type), andBody: body, in: DocumentCollection(unconditionallyBridgedFromObjectiveC: collection)) { completion($0.bridgeToObjectiveC()) }
     }
 
@@ -623,12 +638,12 @@ public class ADAzureData: NSObject {
     // create
     @objc(createPermissionWithId:andMode:inResource:forUserWithId:inDatabaseWithId:completion:)
     public static func create(permissionWithId permissionId: String, mode: ADPermissionMode, in resource: ADResource & ADSupportsPermissionToken, forUser userId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
-        AzureData.create(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceWrapper(resource), forUser: userId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+        AzureData.create(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceSwiftWrapper(resource), forUser: userId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
     }
 
     @objc(createPermissionWithId:andMode:inResource:forUser:completion:)
     public static func create(permissionWithId permissionId: String, mode: ADPermissionMode, in resource: ADResource & ADSupportsPermissionToken, for user: ADUser, completion: @escaping (ADResponse) -> Void) {
-        AzureData.create(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceWrapper(resource), for: User(unconditionallyBridgedFromObjectiveC: user)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.create(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceSwiftWrapper(resource), for: User(unconditionallyBridgedFromObjectiveC: user)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // list
@@ -677,12 +692,12 @@ public class ADAzureData: NSObject {
     // replace
     @objc(replacePermissionWithId:andMode:inResource:forUserWithId:inDatabaseWithId:completion:)
     public static func replace(permissionWithId permissionId: String, mode: ADPermissionMode, in resource: ADResource & ADSupportsPermissionToken, forUser userId: String, inDatabase databaseId: String, completion: @escaping (ADResponse) -> Void) {
-        AzureData.replace(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceWrapper(resource), forUser: userId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
+        AzureData.replace(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceSwiftWrapper(resource), forUser: userId, inDatabase: databaseId) { completion($0.bridgeToObjectiveC()) }
     }
 
     @objc(replacePermissionWithId:andMode:inResource:forUser:completion:)
     public static func replace(permissionWithId permissionId: String, mode: ADPermissionMode, in resource: ADResource & ADSupportsPermissionToken, for user: ADUser, completion: @escaping (ADResponse) -> Void) {
-        AzureData.replace(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceWrapper(resource), for: User(unconditionallyBridgedFromObjectiveC: user)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.replace(permissionWithId: permissionId, mode: mode.permissionMode, in: PermissionEnabledADResourceSwiftWrapper(resource), for: User(unconditionallyBridgedFromObjectiveC: user)) { completion($0.bridgeToObjectiveC()) }
     }
 
     // MARK: - Offers
@@ -723,6 +738,6 @@ public class ADAzureData: NSObject {
 
     @objc(deleteResource:completion:)
     public static func delete(_ resource: ADResource, completion: @escaping (ADResponse) -> Void) {
-        AzureData.delete(ADResourceWrapper(resource)) { completion($0.bridgeToObjectiveC()) }
+        AzureData.delete(ADResourceSwiftWrapper(resource)) { completion($0.bridgeToObjectiveC()) }
     }
 }

--- a/AzureData/Source/Objective-C/ADAzureDataExtensions.swift
+++ b/AzureData/Source/Objective-C/ADAzureDataExtensions.swift
@@ -1,0 +1,339 @@
+//
+//  ADAzureDataExtensions.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+// MARK: - Database
+
+public extension ADDatabase {
+
+    // MARK: - Collections
+
+    @objc(createCollectionWithId:completion:)
+    public func create(collectionWithId collectionId: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.create(collectionWithId: collectionId, in: self, completion: completion)
+    }
+
+    @objc(getCollectionsWithCompletion:)
+    public func getCollections(completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(collectionsIn: self, completion: completion)
+    }
+
+    @objc(getCollectionsWithMaxPerPage:completion:)
+    public func getCollections(maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(collectionsIn: self, maxPerPage: maxPerPage, completion: completion)
+    }
+
+    @objc(getCollectionWithId:completion:)
+    public func get(collectionWithId collectionId: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(collectionWithId: collectionId, in: self, completion: completion)
+    }
+
+    @objc(deleteCollectionWithId:completion:)
+    public func delete(collectionWithId collectionId: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.delete(collectionWithId: collectionId, from: self, completion: completion)
+    }
+
+    // MARK: - Users
+
+    @objc(createUserWithId:completion:)
+    public func create(userWithId userId: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.create(userWithId: userId, in: self, completion: completion)
+    }
+
+    @objc(getUsersWithCompletion:)
+    public func getUsers(completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(usersIn: self, completion: completion)
+    }
+
+    @objc(getUsersWithMaxPerPage:completion:)
+    public func getUsers(maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(usersIn: self, maxPerPage: maxPerPage, completion: completion)
+    }
+
+    @objc(getUserWithId:completion:)
+    public func get(userWithId userId: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(userWithId: userId, in: self, completion: completion)
+    }
+
+    @objc(deleteUser:completion:)
+    public func delete(user: ADUser, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.delete(user, completion: completion)
+    }
+
+    @objc(deleteUserWithId:completion:)
+    public func delete(userWithId userId: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.delete(userWithId: userId, from: self, completion: completion)
+    }
+
+    @objc(replaceUserWithId:withNewUserId:completion:)
+    public func replace(userWithId userId: String, with newUserId: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.replace(userWithId: userId, with: newUserId, in: self, completion: completion)
+    }
+}
+
+// MARK: - Collection
+
+public extension ADDocumentCollection {
+
+    // MARK: - Documents
+
+    @objc(createDocument:completion:)
+    public func create(document: ADDocument, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.create(document: document, in: self, completion: completion)
+    }
+
+    @objc(createOrReplaceDocument:completion:)
+    public func createOrReplace(document: ADDocument, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.createOrReplace(document: document, in: self, completion: completion)
+    }
+
+    @objc(getDocumentsAs:completion:)
+    public func get(documentsAs documentType: ADDocument.Type, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(documentsAs: documentType, in: self, completion: completion)
+    }
+
+    @objc(getDocumentsAs:maxPerPage:completion:)
+    public func get(documentsAs documentType: ADDocument.Type, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(documentsAs: documentType, in: self, maxPerPage: maxPerPage, completion: completion)
+    }
+
+    @objc(getDocumentWithId:as:completion:)
+    public func get(documentWithId documentId: String, as documentType: ADDocument.Type, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(documentWithId: documentId, as: documentType, in: self, completion: completion)
+    }
+
+    @objc(deleteDocument:completion:)
+    public func delete(document: ADDocument, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.delete(document, completion: completion)
+    }
+
+    @objc(deleteDocumentWithId:completion:)
+    public func delete(documentWithId documentId: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.delete(documentWithId: documentId, from: self, completion: completion)
+    }
+
+    @objc(replaceDocument:completion:)
+    public func replace(document: ADDocument, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.replace(document: document, in: self, completion: completion)
+    }
+
+    @objc(queryDocumentsWithQuery:as:completion:)
+    public func query(documentsWith query: ADQuery, as documentType: ADDocument.Type, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.query(documentsIn: self, as: documentType, with: query, completion: completion)
+    }
+
+    @objc(queryDocumentsWithQuery:as:withMaxPerPage:completion:)
+    public func query(documentsWith query: ADQuery, as documentType: ADDocument.Type, maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.query(documentsIn: self, as: documentType, with: query, maxPerPage: maxPerPage, completion: completion)
+    }
+
+    // MARK: - Stored Procedures
+
+    @objc(createStoredProcedureWithId:andBody:completion:)
+    public func create(storedProcedureWithId id: String, andBody body: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.create(storedProcedureWithId: id, andBody: body, in: self, completion: completion)
+    }
+
+    @objc(getStoredProceduresWithCompletion:)
+    public func getStoredProcedures(completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(storedProceduresIn: self, completion: completion)
+    }
+
+    @objc(getStoredProceduresWithMaxPerPage:Completion:)
+    public func getStoredProcedures(maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(storedProceduresIn: self, maxPerPage: maxPerPage, completion: completion)
+    }
+
+    @objc(deleteStoredProcedure:completion:)
+    public func delete(storedProcedure: ADStoredProcedure, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.delete(storedProcedure, completion: completion)
+    }
+
+    @objc(deleteStoredProcedureWithId:completion:)
+    public func delete(storedProcedureWithId id: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.delete(storedProcedureWithId: id, from: self, completion: completion)
+    }
+
+    @objc(replaceStoredProcedureWithId:andBody:completion:)
+    public func replace(storedProcedureWithId id: String, andBody body: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.replace(storedProcedureWithId: id, andBody: body, in: self, completion: completion)
+    }
+
+    @objc(executeStoredProcedure:usingParameters:completion:)
+    public func execute(storedProcedure: ADStoredProcedure, usingParameters parameters: [String]?, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.execute(storedProcedure: storedProcedure, usingParameters: parameters, completion: completion)
+    }
+
+    @objc(executeStoredProcedureWithId:usingParameters:completion:)
+    public func execute(storedProcedureWithId id: String, usingParameters parameters: [String]?, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.execute(storedProcedureWithId: id, usingParameters: parameters, in: self, completion: completion)
+    }
+
+    // MARK: - User Defined Functions
+
+    @objc(createUserDefinedFunctionWithId:andBody:completion:)
+    public func create(userDefinedFunctionWithId id: String, andBody body: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.create(userDefinedFunctionWithId: id, andBody: body, in: self, completion: completion)
+    }
+
+    @objc(getUserDefinedFunctionsWithCompletion:)
+    public func getUserDefinedFunctions(completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(userDefinedFunctionsIn: self, completion: completion)
+    }
+
+    @objc(getUserDefinedFunctionsWithMaxPerPage:completion:)
+    public func getUserDefinedFunctions(maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(userDefinedFunctionsIn: self, maxPerPage: maxPerPage, completion: completion)
+    }
+
+    @objc(deleteUserDefinedFunction:completion:)
+    public func delete(userDefinedFunction: ADUserDefinedFunction, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.delete(userDefinedFunction, completion: completion)
+    }
+
+    @objc(deleteUserDefinedFunctionWithId:completion:)
+    public func delete(userDefinedFunctionWithId id: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.delete(userDefinedFunctionWithId: id, from: self, completion: completion)
+    }
+
+    @objc(replaceUserDefinedFunctionWithId:andBody:completion:)
+    public func replace(userDefinedFunctionWithId id: String, andBody body: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.replace(userDefinedFunctionWithId: id, andBody: body, in: self, completion: completion)
+    }
+
+    // MARK: - Triggers
+
+    @objc(createTriggerWithId:operation:type:andBody:completion:)
+    public func create(triggerWithId id: String, operation: ADTrigger.ADTriggerOperation, type: ADTrigger.ADTriggerType, andBody body: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.create(triggerWithId: id, operation: operation, type: type, andBody: body, in: self, completion: completion)
+    }
+
+    @objc(getTriggersWithCompletion:)
+    public func getTriggers(completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(triggersIn: self, completion: completion)
+    }
+
+    @objc(getTriggersWithMaxPerPage:completion:)
+    public func getTriggers(maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(triggersIn: self, maxPerPage: maxPerPage, completion: completion)
+    }
+
+    @objc(deleteTrigger:completion:)
+    public func delete(trigger: ADTrigger, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.delete(trigger, completion: completion)
+    }
+
+    @objc(deleteTriggerWithId:completion:)
+    public func delete(triggerWithId triggerId: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.delete(triggerWithId: triggerId, from: self, completion: completion)
+    }
+
+    @objc(replaceTriggerWithId:operation:type:andBody:completion:)
+    public func replace(triggerWithId triggerId: String, operation: ADTrigger.ADTriggerOperation, type: ADTrigger.ADTriggerType, andBody body: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.replace(triggerWithId: triggerId, operation: operation, type: type, andBody: body, in: self, completion: completion)
+    }
+}
+
+// MARK: - Document
+
+public extension ADDocument {
+
+    // MARK: - Attachments
+
+    @objc(createAttachmentWithId:contentType:andMediaUrl:completion:)
+    public func create(attachmentWithId attachmentId: String, contentType: String, andMediaUrl mediaUrl: URL, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.create(attachmentWithId: attachmentId, contentType: contentType, andMediaUrl: mediaUrl, on: self, completion: completion)
+    }
+
+    @objc(createAttachmentWithId:contentType:name:andMedia:completion:)
+    public func create(attachmentWithId attachmentId: String, contentType: String, name mediaName: String, with media: Data, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.create(attachmentWithId: attachmentId, contentType: contentType, name: mediaName, with: media, on: self, completion: completion)
+    }
+
+    @objc(getAttachmentsWithCompletion:)
+    public func getAttachments(completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(attachmentsOn: self, completion: completion)
+    }
+
+    @objc(getAttachmentsWithMaxPerPage:completion:)
+    public func getAttachments(maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(attachmentsOn: self, maxPerPage: maxPerPage, completion: completion)
+    }
+
+    @objc(deleteAttachment:completion:)
+    public func delete(attachment: ADAttachment, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.delete(attachment, completion: completion)
+    }
+
+    @objc(deleteAttachmentWithId:completion:)
+    public func delete(attachmentWithId attachmentId: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.delete(attachmentWithId: attachmentId, from: self, completion: completion)
+    }
+
+    @objc(replaceAttachmentWithId:contentType:andMediaUrl:completion:)
+    public func replace(attachmentWithId attachmentId: String, contentType: String, andMediaUrl mediaUrl: URL, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.replace(attachmentWithId: attachmentId, contentType: contentType, andMediaUrl: mediaUrl, on: self, completion: completion)
+    }
+
+    @objc(replaceAttachmentWithId:contentType:name:andMedia:completion:)
+    public func replace(attachmentWithId attachmentId: String, contentType: String, name mediaName: String, with media: Data, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.replace(attachmentWithId: attachmentId, contentType: contentType, name: mediaName, with: media, on: self, completion: completion)
+    }
+}
+
+// MARK: - User
+
+public extension ADUser {
+
+    // MARK: - Permissions
+
+    @objc(createPermissionWithId:andMode:inResource:completion:)
+    public func create(permissionWithId permissionId: String, mode permissionMode: ADPermissionMode, in resource: ADResource & ADSupportsPermissionToken, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.create(permissionWithId: permissionId, mode: permissionMode, in: resource, for: self, completion: completion)
+    }
+
+    @objc(getPermissionsWithCompletion:)
+    public func getPermissions(completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(permissionsFor: self, completion: completion)
+    }
+
+    @objc(getPermissionsWithMaxPerPage:completion:)
+    public func getPermissions(maxPerPage: Int, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(permissionsFor: self, maxPerPage: maxPerPage, completion: completion)
+    }
+
+    @objc(getPermissionWithId:completion:)
+    public func get(permissionWithId permissionId: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.get(permissionWithId: permissionId, for: self, completion: completion)
+    }
+
+    @objc(deletePermission:completion:)
+    public func delete(permission: ADPermission, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.delete(permission, completion: completion)
+    }
+
+    @objc(deletePermissionWithId:completion:)
+    public func delete(permissionWithId permissionId: String, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.delete(permissionWithId: permissionId, from: self, completion: completion)
+    }
+
+    @objc(replacePermissionWithId:mode:inResource:completion:)
+    public func replace(permissionWithId permissionId: String, mode permissionMode: ADPermissionMode, in resource: ADResource & ADSupportsPermissionToken, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.replace(permissionWithId: permissionId, mode: permissionMode, in: resource, for: self, completion: completion)
+    }
+}
+
+// MARK: - Stored Procedure
+
+public extension ADStoredProcedure {
+    @objc(executeUsingParameters:completion:)
+    public func execute(usingParameters: [String]?, completion: @escaping (ADResponse) -> Void) {
+        ADAzureData.execute(storedProcedure: self, usingParameters: usingParameters, completion: completion)
+    }
+}

--- a/AzureData/Source/Objective-C/ADConflictStrategy.swift
+++ b/AzureData/Source/Objective-C/ADConflictStrategy.swift
@@ -1,0 +1,64 @@
+//
+//  ADConflictStrategy.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+public typealias ADConflictResolver = (_ local: ADResource, _ remote: ADResource) -> ADResource
+
+@objc(ADConflictStrategy)
+public class ADConflictStrategy: NSObject {
+}
+
+@objc(ADNoConflictStrategy)
+public class ADNoConflictStrategy: ADConflictStrategy {
+}
+
+@objc(ADOverwriteConflictStrategy)
+public class ADOverwriteConflictStrategy: ADConflictStrategy {
+}
+
+@objc(ADCustomConflictStrategy)
+public class ADCustomConflictStrategy: ADConflictStrategy {
+    @objc
+    public var resolver: ADConflictResolver
+
+    @objc(initWithResolver:)
+    public init(resolver: @escaping ADConflictResolver) {
+        self.resolver = resolver
+    }
+}
+
+extension ConflictStrategy {
+    var bridgedToObjectiveC: ADConflictStrategy {
+        switch self {
+        case .none:
+            return ADNoConflictStrategy()
+        case .overwrite:
+            return ADOverwriteConflictStrategy()
+        case .custom(let resolver):
+            return ADCustomConflictStrategy(resolver: { local, remote in
+                return CodableResourceObjectiveWrapper(resolver(ADResourceSwiftWrapper(local), ADResourceSwiftWrapper(remote)))
+            })
+        }
+    }
+
+    init(bridgedFromObjectiveC: ADConflictStrategy) {
+        switch bridgedFromObjectiveC {
+        case is ADNoConflictStrategy:
+            self = .none
+        case is ADOverwriteConflictStrategy:
+            self = .overwrite
+        case let strategy as ADCustomConflictStrategy:
+            self = .custom({ local, remote in
+                return ADResourceSwiftWrapper(strategy.resolver(CodableResourceObjectiveWrapper(local), CodableResourceObjectiveWrapper(remote)))
+            })
+        default:
+            self = .none
+        }
+    }
+}

--- a/AzureData/Source/Objective-C/ADDateEncoders.swift
+++ b/AzureData/Source/Objective-C/ADDateEncoders.swift
@@ -1,0 +1,39 @@
+//
+//  ADDateEncoders.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+import AzureCore
+
+@objc(ADDateEncoders)
+public class ADDateEncoders: NSObject {
+    @objc(encodeTimestamp:)
+    public static func encodeTimestamp(_ date: Date?) -> NSNumber? {
+        guard let date = date else { return nil }
+        return NSNumber(value: date.timeIntervalSince1970)
+    }
+
+    @objc(decodeTimestampFrom:)
+    public static func decodeTimestamp(from value: Any?) -> Date? {
+        if let date = value as? Date { return date }
+        guard let double = (value as? NSNumber)?.doubleValue else { return nil }
+        return Date(timeIntervalSince1970: double)
+    }
+
+    @objc(encodeISO8601Date:)
+    public static func encodeISO8601Date(_ date: Date?) -> String? {
+        guard let date = date else { return nil }
+        return DateFormat.getRoundTripIso8601Formatter().roundTripIso8601StringWithMicroseconds(from: date)
+    }
+
+    @objc(decodeISO8601From:)
+    public static func decodeISO8601Date(from value: Any?) -> Date? {
+        if let date = value as? Date { return date }
+        guard let string = value as? String else { return nil }
+        return DateFormat.getRoundTripIso8601Formatter().roundTripIso8601DateWithMicroseconds(from: string)
+    }
+}

--- a/AzureData/Source/Objective-C/ADPermissionProvider.swift
+++ b/AzureData/Source/Objective-C/ADPermissionProvider.swift
@@ -11,7 +11,6 @@ import AzureCore
 
 @objc(ADPermissionProvider)
 public protocol ADPermissionProvider {
-
     var configuration: ADPermissionProviderConfiguration! { get set }
 
     func getPermission(forCollectionWithId collectionId: String, inDatabase databaseId: String, withPermissionMode mode: ADPermissionMode, completion: @escaping (ADResponse) -> Void)

--- a/AzureData/Source/Objective-C/ADPermissionProvider.swift
+++ b/AzureData/Source/Objective-C/ADPermissionProvider.swift
@@ -1,0 +1,28 @@
+//
+//  ADPermissionProvider.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+import AzureCore
+
+@objc(ADPermissionProvider)
+public protocol ADPermissionProvider {
+
+    var configuration: ADPermissionProviderConfiguration! { get set }
+
+    func getPermission(forCollectionWithId collectionId: String, inDatabase databaseId: String, withPermissionMode mode: ADPermissionMode, completion: @escaping (ADResponse) -> Void)
+
+    func getPermission(forDocumentWithId documentId: String, inCollection collectionId: String, inDatabase databaseId: String, withPermissionMode mode: ADPermissionMode, completion: @escaping (ADResponse) -> Void)
+
+    func getPermission(forAttachmentsWithId attachmentId: String, onDocument documentId: String, inCollection collectionId: String, inDatabase databaseId: String, withPermissionMode mode: ADPermissionMode, completion: @escaping (ADResponse) -> Void)
+
+    func getPermission(forStoredProcedureWithId storedProcedureId: String, inCollection collectionId: String, inDatabase databaseId: String, withPermissionMode mode: ADPermissionMode, completion: @escaping (ADResponse) -> Void)
+
+    func getPermission(forUserDefinedFunctionWithId functionId: String, inCollection collectionId: String, inDatabase databaseId: String, withPermissionMode mode: ADPermissionMode, completion: @escaping (ADResponse) -> Void)
+
+    func getPermission(forTriggerWithId triggerId: String, inCollection collectionId: String, inDatabase databaseId: String, withPermissionMode mode: ADPermissionMode, completion: @escaping (ADResponse) -> Void)
+}

--- a/AzureData/Source/Objective-C/ADPermissionProviderConfiguration.swift
+++ b/AzureData/Source/Objective-C/ADPermissionProviderConfiguration.swift
@@ -1,0 +1,48 @@
+//
+//  ADPermissionProviderConfiguration.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADPermissionProviderConfiguration)
+public class ADPermissionProviderConfiguration: NSObject {
+    @objc
+    public static let `default` = ADPermissionProviderConfiguration()
+
+    @objc
+    public var defaultPermissionMode = ADPermissionMode.read
+
+    @objc
+    public var defaultResourceType: ADResourceType = .collection
+
+    @objc
+    public var defaultTokenDuration: Double = 3600
+
+    @objc
+    public var tokenRefreshThreshold: Double = 600
+}
+
+extension PermissionProviderConfiguration: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADPermissionProviderConfiguration
+
+    func bridgeToObjectiveC() -> ADPermissionProviderConfiguration {
+        let configuration = ADPermissionProviderConfiguration()
+        configuration.defaultPermissionMode = ADPermissionMode(defaultPermissionMode)
+        configuration.defaultResourceType = defaultResourceType?.bridgeToObjectiveC() ?? .collection
+        configuration.defaultTokenDuration = defaultTokenDuration
+        configuration.tokenRefreshThreshold = tokenRefreshThreshold
+
+        return configuration
+    }
+
+    init?(bridgedFromObjectiveC: ADPermissionProviderConfiguration) {
+        defaultPermissionMode = bridgedFromObjectiveC.defaultPermissionMode.permissionMode
+        defaultResourceType = ResourceType(bridgedFromObjectiveC: bridgedFromObjectiveC.defaultResourceType)
+        defaultTokenDuration = bridgedFromObjectiveC.defaultTokenDuration
+        tokenRefreshThreshold = bridgedFromObjectiveC.tokenRefreshThreshold
+    }
+}

--- a/AzureData/Source/Objective-C/ADPermissionProviderConfiguration.swift
+++ b/AzureData/Source/Objective-C/ADPermissionProviderConfiguration.swift
@@ -13,17 +13,33 @@ public class ADPermissionProviderConfiguration: NSObject {
     @objc
     public static let `default` = ADPermissionProviderConfiguration()
 
+    // get readWrite token even for read operations to prevent scenario of
+    // getting a read token for a read operation then subsequently performing
+    // a write operation on the same resource requiring another round trip to
+    // server to get a token with write permissions.
+    //
+    // if this is set to .all, should always request a readWrite token from server
+    //
+    // default: ADPermissionModeRead
     @objc
     public var defaultPermissionMode = ADPermissionMode.read
 
+    // this specifies the at what level of the resource hierarchy
+    // (Database/Collection/Document) to request a resource token
+    //
+    // for example, if this property is set to .collection and the user tries to
+    // write to a document, we'd request a readWrite resource token for the
+    // entire collection versus requesting a token only for the document
+    //
+    // default: ADResourceTypeCollection
     @objc
     public var defaultResourceType: ADResourceType = .collection
 
     @objc
-    public var defaultTokenDuration: Double = 3600
+    public var defaultTokenDuration: Double = 3600 // 1 hour
 
     @objc
-    public var tokenRefreshThreshold: Double = 600
+    public var tokenRefreshThreshold: Double = 600 // 10 minutes
 }
 
 extension PermissionProviderConfiguration: ObjectiveCBridgeable {

--- a/AzureData/Source/Objective-C/ADPermissionProviderConfiguration.swift
+++ b/AzureData/Source/Objective-C/ADPermissionProviderConfiguration.swift
@@ -39,7 +39,7 @@ extension PermissionProviderConfiguration: ObjectiveCBridgeable {
         return configuration
     }
 
-    init?(bridgedFromObjectiveC: ADPermissionProviderConfiguration) {
+    init(bridgedFromObjectiveC: ADPermissionProviderConfiguration) {
         defaultPermissionMode = bridgedFromObjectiveC.defaultPermissionMode.permissionMode
         defaultResourceType = ResourceType(bridgedFromObjectiveC: bridgedFromObjectiveC.defaultResourceType)
         defaultTokenDuration = bridgedFromObjectiveC.defaultTokenDuration

--- a/AzureData/Source/Objective-C/ADQuery.swift
+++ b/AzureData/Source/Objective-C/ADQuery.swift
@@ -1,0 +1,152 @@
+//
+//  ADQuery.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADQuery)
+public class ADQuery: NSObject {
+    internal var query: Query
+
+    @objc
+    public override init() {
+        self.query = Query()
+        super.init()
+    }
+
+    @objc
+    public func from(_ type: String) -> ADQuery {
+        query = query.from(type)
+        return self
+    }
+
+    @objc(where:isString:)
+    public func `where`(_ property: String, is value: String) -> ADQuery {
+        query = query.where(property, is: value)
+        return self
+    }
+
+    @objc(where:isInt:)
+    public func `where`(_ property: String, is value: Int) -> ADQuery {
+        query = query.where(property, is: value)
+        return self
+    }
+
+    @objc(where:isNotString:)
+    public func `where`(_ property: String, isNot value: String) -> ADQuery {
+        query = query.where(property, isNot: value)
+        return self
+    }
+
+    @objc(where:isNotInt:)
+    public func `where`(_ property: String, isNot value: Int) -> ADQuery {
+        query = query.where(property, isNot: value)
+        return self
+    }
+
+    @objc(where:isGreaterThanString:)
+    public func `where`(_ property: String, isGreaterThan value: String) -> ADQuery {
+        query = query.where(property, isGreaterThan: value)
+        return self
+    }
+
+    @objc(where:isGreaterThanInt:)
+    public func `where`(_ property: String, isGreaterThan value: Int) -> ADQuery {
+        query = query.where(property, isGreaterThan: value)
+        return self
+    }
+
+    @objc(where:isLessThanString:)
+    public func `where`(_ property: String, isLessThan value: String) -> ADQuery {
+        query = query.where(property, isLessThan: value)
+        return self
+    }
+
+    @objc(where:isLessThanInt:)
+    public func `where`(_ property: String, isLessThan value: Int) -> ADQuery {
+        query = query.where(property, isLessThan: value)
+        return self
+    }
+
+    @objc(and:isString:)
+    public func and(_ property: String, is value: String) -> ADQuery {
+        query = query.and(property, is: value)
+        return self
+    }
+
+    @objc(and:isInt:)
+    public func and(_ property: String, is value: Int) -> ADQuery {
+        query = query.and(property, is: value)
+        return self
+    }
+
+    @objc(and:isNotString:)
+    public func and(_ property: String, isNot value: String) -> ADQuery {
+        query = query.and(property, isNot: value)
+        return self
+    }
+
+    @objc(and:isNotInt:)
+    public func and(_ property: String, isNot value: Int) -> ADQuery {
+        query = query.and(property, isNot: value)
+        return self
+    }
+
+    @objc(and:isGreaterThanString:)
+    public func and(_ property: String, isGreaterThan value: String) -> ADQuery {
+        query = query.and(property, isGreaterThan: value)
+        return self
+    }
+
+    @objc(and:isGreaterThanInt:)
+    public func and(_ property: String, isGreaterThan value: Int) -> ADQuery {
+        query = query.and(property, isGreaterThan: value)
+        return self
+    }
+
+    @objc(and:isGreaterThanOrEqualToString:)
+    public func and(_ property: String, isGreaterThanOrEqualTo value: String) -> ADQuery {
+        query = query.and(property, isGreaterThanOrEqualTo: value)
+        return self
+    }
+
+    @objc(and:isGreaterThanOrEqualToInt:)
+    public func and(_ property: String, isGreaterThanOrEqualTo value: Int) -> ADQuery {
+        query = query.and(property, isGreaterThanOrEqualTo: value)
+        return self
+    }
+
+    @objc(and:isLessThanString:)
+    public func and(_ property: String, isLessThan value: String) -> ADQuery {
+        query = query.and(property, isLessThan: value)
+        return self
+    }
+
+    @objc(and:isLessThanInt:)
+    public func and(_ property: String, isLessThan value: Int) -> ADQuery {
+        query = query.and(property, isLessThan: value)
+        return self
+    }
+
+    @objc(and:isLessThanOrEqualToString:)
+    public func and(_ property: String, isLessThanOrEqualTo value: String) -> ADQuery {
+        query = query.and(property, isLessThanOrEqualTo: value)
+        return self
+    }
+
+    @objc(and:isLessThanOrEqualToInt:)
+    public func and(_ property: String, isLessThanOrEqualTo value: Int) -> ADQuery {
+        query = query.and(property, isLessThanOrEqualTo: value)
+        return self
+    }
+
+    @objc
+    public func orderBy(_ property: String, descending: Bool = false) -> ADQuery {
+        query = query.orderBy(property, descending: descending)
+        return self
+    }
+}

--- a/AzureData/Source/Objective-C/ADResourceSystemKeys.swift
+++ b/AzureData/Source/Objective-C/ADResourceSystemKeys.swift
@@ -1,0 +1,17 @@
+//
+//  ADResourceSystemKeys.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+enum ADResourceSystemKeys: String, CodingKey {
+    case id
+    case resourceId         = "_rid"
+    case selfLink           = "_self"
+    case etag               = "_etag"
+    case timestamp          = "_ts"
+}

--- a/AzureData/Source/Objective-C/ADResourceType.swift
+++ b/AzureData/Source/Objective-C/ADResourceType.swift
@@ -1,0 +1,112 @@
+//
+//  ADResourceType.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADResourceType)
+public enum ADResourceType: Int {
+    @objc(ADResourceTypeDatabase)
+    case database
+
+    @objc(ADResourceTypeUser)
+    case user
+
+    @objc(ADResourceTypePermission)
+    case permission
+
+    @objc(ADResourceTypeCollection)
+    case collection
+
+    @objc(ADResourceTypeStoredProcedure)
+    case storedProcedure
+
+    @objc(ADResourceTypeTrigger)
+    case trigger
+
+    @objc(ADResourceTypeUDF)
+    case udf
+
+    @objc(ADResourceTypeDocument)
+    case document
+
+    @objc(ADResourceTypeAttachment)
+    case attachment
+
+    @objc(ADResourceTypeOffer)
+    case offer
+
+    public var description: String {
+        switch self {
+        case .database:
+            return "dbs"
+        case .user:
+            return "users"
+        case .permission:
+            return "permissions"
+        case .collection:
+            return "colls"
+        case .storedProcedure:
+            return "sprocs"
+        case .trigger:
+            return "triggers"
+        case  .udf:
+            return "udfs"
+        case .document:
+            return "docs"
+        case .attachment:
+            return "attachments"
+        case .offer:
+            return "offers"
+        }
+    }
+
+    public var path: String {
+        return swiftResourceType.path
+    }
+
+    public func isDecendent(of rt: ADResourceType) -> Bool {
+        return swiftResourceType.isDecendent(of: rt.swiftResourceType)
+    }
+
+    public func isAncestor(of rt: ADResourceType) -> Bool {
+        return swiftResourceType.isAncestor(of: rt.swiftResourceType)
+    }
+
+    public var supportsPermissionToken: Bool {
+        return swiftResourceType.supportsPermissionToken
+    }
+
+    public static var ancestors: [ADResourceType] {
+        return [.database, .user, .collection, .document]
+    }
+
+    private var swiftResourceType: ResourceType { return ResourceType(bridgedFromObjectiveC: self)! }
+}
+
+extension ResourceType {
+    func bridgeToObjectiveC() -> ADResourceType {
+        switch self {
+        case .database: return .database
+        case .user: return .user
+        case .permission: return .permission
+        case .collection: return .collection
+        case .storedProcedure: return .storedProcedure
+        case .trigger: return .trigger
+        case .udf: return .udf
+        case .document: return .document
+        case .attachment: return .attachment
+        case .offer: return .offer
+        }
+    }
+
+    init?(bridgedFromObjectiveC: ADResourceType?) {
+        guard let source = bridgedFromObjectiveC else { return nil }
+        guard let rt = ResourceType(rawValue: source.description) else { return nil }
+        self = rt
+    }
+}

--- a/AzureData/Source/Objective-C/ADResponse.swift
+++ b/AzureData/Source/Objective-C/ADResponse.swift
@@ -1,0 +1,159 @@
+//
+//  ADResponse.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+import AzureCore
+
+@objc(ADResponse)
+public class ADResponse: NSObject {
+
+    @objc
+    public var request: URLRequest? { return _response.request }
+
+    @objc
+    public var response: HTTPURLResponse? { return _response.response }
+
+    @objc
+    public var data: Data? { return _response.data }
+
+    @objc
+    public var result: ObjCResult { return ObjCResult(_response.result) }
+
+    @objc
+    public var resource: AnyObject? { return result.resource }
+
+    @objc
+    public var error: Error? { return result.error }
+
+    @objc
+    public var fromCache: Bool { return _response.fromCache }
+
+    @objc
+    public var metadata: ADResponseMetadata? { return ADResponseMetadata(_response.metadata) }
+
+    private var _response: Response<AnyObject>
+
+    @objc
+    public init(request: URLRequest?, data: Data?, response: HTTPURLResponse?, result: ObjCResult, fromCache: Bool = false) {
+        self._response = Response(request: request, data: data, response: response, result: Result<AnyObject>(bridgedFromObjectiveC: result), fromCache: fromCache)
+    }
+
+    internal init(_ response: Response<AnyObject>) {
+        self._response = response
+    }
+
+    internal init<T: AnyObject>(erasingTypeOf: Response<T>) {
+        self._response = erasingTypeOf.map { $0 as AnyObject }
+    }
+}
+
+@objc(ADResult)
+public class ObjCResult: NSObject {
+    @objc
+    public var isSuccess: Bool { return result.isSuccess }
+
+    @objc
+    public var isFailure: Bool { return result.isFailure }
+
+    @objc
+    public var resource: AnyObject? { return result.resource }
+
+    @objc
+    public var error: Error? { return result.error }
+
+    private var result: Result<AnyObject>
+
+    @objc
+    public init(resource: AnyObject) {
+        self.result = .success(resource)
+    }
+
+    @objc
+    public init(error: Error) {
+        self.result = .failure(error)
+    }
+
+    internal init(_ result: Result<AnyObject>) {
+        self.result = result
+    }
+}
+
+// MARK: -
+
+extension Response: ObjectiveCBridgeable where T: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADResponse
+
+    func bridgeToObjectiveC() -> ADResponse {
+        return ADResponse(self.map { $0.bridgeToObjectiveC() })
+    }
+
+    init?(bridgedFromObjectiveC: ADResponse) {
+        self.init(
+            request: bridgedFromObjectiveC.request,
+            data: bridgedFromObjectiveC.data,
+            response: bridgedFromObjectiveC.response,
+            result: Result<T>(unconditionallyBridgedFromObjectiveC: bridgedFromObjectiveC.result),
+            fromCache: bridgedFromObjectiveC.fromCache
+        )
+    }
+}
+
+extension Response where T == DictionaryDocument {
+    func bridgeToObjectiveC(withDocumentType documentType: ADDocument.Type) -> ADResponse {
+        if let resource = resource, let document = documentType.init(from: resource.dataMergedWithSystemKeysAndValues) {
+            return ADResponse(erasingTypeOf: self.map { _ in document })
+        }
+
+        return ADResponse(Response<AnyObject>(request: request, data: data, response: response, result: Result<AnyObject>.failure(DocumentClientError(withKind: .internalError)), fromCache: fromCache))
+    }
+}
+
+extension Response where T == Resources<DictionaryDocument> {
+    func bridgeToObjectiveC(withDocumentType documentType: ADDocument.Type) -> ADResponse {
+        return ADResponse(erasingTypeOf: self.map { resources -> ADResources in
+            let items = resources.items.compactMap { documentType.init(from: $0.dataMergedWithSystemKeysAndValues) }
+            return ADResources(resourceId: resources.resourceId, count: items.count, items: items)
+        })
+    }
+}
+
+extension Result: ObjectiveCBridgeable where T: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ObjCResult
+
+    func bridgeToObjectiveC() -> ObjCResult {
+        return ObjCResult(self.map { $0.bridgeToObjectiveC() })
+    }
+
+    init?(bridgedFromObjectiveC: ObjCResult) {
+        if bridgedFromObjectiveC.isSuccess {
+            self = Result<T>.success(T.init(bridgedFromObjectiveC: bridgedFromObjectiveC.resource! as! T.ObjectiveCType)!)
+            return
+        }
+
+        self = Result<T>.failure(bridgedFromObjectiveC.error!)
+    }
+}
+
+extension Result where T == AnyObject {
+    init(bridgedFromObjectiveC: ObjCResult) {
+        if bridgedFromObjectiveC.isSuccess {
+            self = Result<T>.success(bridgedFromObjectiveC.resource!)
+            return
+        }
+
+        self = Result<T>.failure(bridgedFromObjectiveC.error!)
+    }
+}
+
+extension Data: ObjectiveCBridgeable {
+    typealias ObjectiveCType = NSData
+
+    func bridgeToObjectiveC() -> NSData {
+        return NSData(data: self)
+    }
+}

--- a/AzureData/Source/Objective-C/ADResponse.swift
+++ b/AzureData/Source/Objective-C/ADResponse.swift
@@ -92,12 +92,12 @@ extension Response: ObjectiveCBridgeable where T: ObjectiveCBridgeable {
         return ADResponse(self.map { $0.bridgeToObjectiveC() })
     }
 
-    init?(bridgedFromObjectiveC: ADResponse) {
+    init(bridgedFromObjectiveC: ADResponse) {
         self.init(
             request: bridgedFromObjectiveC.request,
             data: bridgedFromObjectiveC.data,
             response: bridgedFromObjectiveC.response,
-            result: Result<T>(unconditionallyBridgedFromObjectiveC: bridgedFromObjectiveC.result),
+            result: Result<T>(bridgedFromObjectiveC: bridgedFromObjectiveC.result),
             fromCache: bridgedFromObjectiveC.fromCache
         )
     }
@@ -129,19 +129,18 @@ extension Result: ObjectiveCBridgeable where T: ObjectiveCBridgeable {
         return ADResult(self.map { $0.bridgeToObjectiveC() })
     }
 
-    init?(bridgedFromObjectiveC: ADResult) {
+    init(bridgedFromObjectiveC: ADResult) {
         guard bridgedFromObjectiveC.isSuccess else {
             self = Result<T>.failure(bridgedFromObjectiveC.error!)
             return
         }
 
-        guard let objectiveCResource = bridgedFromObjectiveC.resource! as? T.ObjectiveCType,
-              let resource = T.init(bridgedFromObjectiveC: objectiveCResource) else {
-                self = Result<T>.failure(DocumentClientError(withKind: .internalError))
-                return
+        guard let objectiveCResource = bridgedFromObjectiveC.resource! as? T.ObjectiveCType else {
+            self = Result<T>.failure(DocumentClientError(withKind: .internalError))
+            return
         }
 
-        self = Result<T>.success(resource)
+        self = Result<T>.success(T.init(bridgedFromObjectiveC: objectiveCResource))
     }
 }
 
@@ -161,5 +160,9 @@ extension Data: ObjectiveCBridgeable {
 
     func bridgeToObjectiveC() -> NSData {
         return NSData(data: self)
+    }
+
+    init(bridgedFromObjectiveC: NSData) {
+        self = bridgedFromObjectiveC as Data
     }
 }

--- a/AzureData/Source/Objective-C/ADSupportsPermissionToken.swift
+++ b/AzureData/Source/Objective-C/ADSupportsPermissionToken.swift
@@ -1,0 +1,12 @@
+//
+//  ADSupportsPermissionToken.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADSupportsPermissionToken)
+public protocol ADSupportsPermissionToken {}

--- a/AzureData/Source/Objective-C/ObjectiveCBridgeable.swift
+++ b/AzureData/Source/Objective-C/ObjectiveCBridgeable.swift
@@ -1,0 +1,27 @@
+//
+//  ObjectiveCBridgeable.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+protocol ObjectiveCBridgeable {
+    associatedtype ObjectiveCType: AnyObject
+
+    func bridgeToObjectiveC() -> ObjectiveCType
+
+    init?(bridgedFromObjectiveC: ObjectiveCType)
+}
+
+extension ObjectiveCBridgeable {
+    init?(bridgedFromObjectiveC: ObjectiveCType) {
+        return nil
+    }
+
+    init(unconditionallyBridgedFromObjectiveC bridgedFromObjectiveC: ObjectiveCType) {
+        self.init(bridgedFromObjectiveC: bridgedFromObjectiveC)!
+    }
+}

--- a/AzureData/Source/Objective-C/ObjectiveCBridgeable.swift
+++ b/AzureData/Source/Objective-C/ObjectiveCBridgeable.swift
@@ -8,10 +8,19 @@
 
 import Foundation
 
+/// This protocol is used internally to expose a Swift
+/// type to a type that is representable in Objective-C
+/// as the type `ObjectiveCType` or one of its subclasses.
 protocol ObjectiveCBridgeable {
+    /// The type corresponding to `Self` in Objective-C.
     associatedtype ObjectiveCType: AnyObject
 
+    /// Converts `self` to its corresponding
+    /// `ObjectiveCType`.
     func bridgeToObjectiveC() -> ObjectiveCType
 
+    /// Reconstructs a Swift value of type `Self`
+    /// from its corresponding value of type
+    /// `ObjectiveCType`.
     init(bridgedFromObjectiveC: ObjectiveCType)
 }

--- a/AzureData/Source/Objective-C/ObjectiveCBridgeable.swift
+++ b/AzureData/Source/Objective-C/ObjectiveCBridgeable.swift
@@ -13,15 +13,5 @@ protocol ObjectiveCBridgeable {
 
     func bridgeToObjectiveC() -> ObjectiveCType
 
-    init?(bridgedFromObjectiveC: ObjectiveCType)
-}
-
-extension ObjectiveCBridgeable {
-    init?(bridgedFromObjectiveC: ObjectiveCType) {
-        return nil
-    }
-
-    init(unconditionallyBridgedFromObjectiveC bridgedFromObjectiveC: ObjectiveCType) {
-        self.init(bridgedFromObjectiveC: bridgedFromObjectiveC)!
-    }
+    init(bridgedFromObjectiveC: ObjectiveCType)
 }

--- a/AzureData/Source/Objective-C/ObjectiveCUtilities.swift
+++ b/AzureData/Source/Objective-C/ObjectiveCUtilities.swift
@@ -1,0 +1,60 @@
+//
+//  ObjCExtensions.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+extension NSDictionary {
+    func data() throws -> Data {
+        if #available(iOS 11.0, *) {
+            return try JSONSerialization.data(withJSONObject: self, options: .sortedKeys)
+        } else {
+            return try JSONSerialization.data(withJSONObject: self, options: .prettyPrinted)
+        }
+    }
+
+    func value(forKey key: CodingKey) -> Any? {
+        return self.value(forKey: key.stringValue)
+    }
+
+    func setValue(_ value: Any?, forKey key: CodingKey) {
+        self.setValue(value, forKey: key.stringValue)
+    }
+
+    subscript(key: CodingKey) -> Any? {
+        get { return self.value(forKey: key) }
+        set(newValue) { self.setValue(newValue, forKey: key) }
+    }
+
+    var swifty: [AnyHashable: Any] {
+        var dict = [AnyHashable: Any]()
+
+        for (key, value) in self {
+            dict[key as! String] = value
+        }
+
+        return dict
+    }
+}
+
+extension Data {
+    func dictionary() throws -> NSDictionary {
+        return try JSONSerialization.jsonObject(with: self, options: .allowFragments) as! NSDictionary
+    }
+}
+
+extension Int {
+    static let `nil`: Int = -1
+}
+
+extension Int16 {
+    static let `nil`: Int16 = -1
+}
+
+extension Double {
+    static let `nil`: Double = -1.0
+}

--- a/AzureData/Source/Objective-C/ObjectiveCUtilities.swift
+++ b/AzureData/Source/Objective-C/ObjectiveCUtilities.swift
@@ -9,14 +9,6 @@
 import Foundation
 
 extension NSDictionary {
-    func data() throws -> Data {
-        if #available(iOS 11.0, *) {
-            return try JSONSerialization.data(withJSONObject: self, options: .sortedKeys)
-        } else {
-            return try JSONSerialization.data(withJSONObject: self, options: .prettyPrinted)
-        }
-    }
-
     func value(forKey key: CodingKey) -> Any? {
         return self.value(forKey: key.stringValue)
     }
@@ -38,6 +30,10 @@ extension NSDictionary {
         }
 
         return dict
+    }
+
+    func data() throws -> Data {
+        return try JSONSerialization.data(withJSONObject: self, options: .prettyPrinted)
     }
 }
 

--- a/AzureData/Source/Objective-C/ObjectiveCWrappers.swift
+++ b/AzureData/Source/Objective-C/ObjectiveCWrappers.swift
@@ -8,6 +8,10 @@
 
 import Foundation
 
+/// Wraps a `CodableResource` and allows it to be
+/// represented as an `ADResource`.
+/// - Note: Only the system properties of the `CodableResource`
+///         will be visible and accessible.
 class CodableResourceObjectiveWrapper: ADResource {
     private typealias CodingKeys = ADResourceSystemKeys
 
@@ -26,6 +30,8 @@ class CodableResourceObjectiveWrapper: ADResource {
         self.timestamp = resource.timestamp
         self.altLink = resource.altLink
     }
+
+    // MARK: - ADCodable
 
     public required init?(from dictionary: NSDictionary) {
         guard let id = dictionary[CodingKeys.id] as? String else { return nil }

--- a/AzureData/Source/Objective-C/ObjectiveCWrappers.swift
+++ b/AzureData/Source/Objective-C/ObjectiveCWrappers.swift
@@ -1,0 +1,53 @@
+//
+//  ObjectiveCWrappers.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+class CodableResourceObjectiveWrapper: ADResource {
+    private typealias CodingKeys = ADResourceSystemKeys
+
+    var id: String
+    var resourceId: String
+    var selfLink: String?
+    var etag: String?
+    var timestamp: Date?
+    var altLink: String?
+
+    init(_ resource: CodableResource) {
+        self.id = resource.id
+        self.resourceId = resource.resourceId
+        self.selfLink = resource.selfLink
+        self.etag = resource.etag
+        self.timestamp = resource.timestamp
+        self.altLink = resource.altLink
+    }
+
+    public required init?(from dictionary: NSDictionary) {
+        guard let id = dictionary[CodingKeys.id] as? String else { return nil }
+        guard let resourceId = dictionary[CodingKeys.resourceId] as? String else { return nil }
+
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = dictionary[CodingKeys.selfLink] as? String
+        self.etag = dictionary[CodingKeys.etag] as? String
+        self.timestamp = ADDateEncoders.decodeTimestamp(from: dictionary[CodingKeys.timestamp])
+        self.altLink = nil
+    }
+
+    public func encode() -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+
+        dictionary[CodingKeys.id] = id
+        dictionary[CodingKeys.resourceId] = resourceId
+        dictionary[CodingKeys.selfLink] = selfLink
+        dictionary[CodingKeys.etag] = etag
+        dictionary[CodingKeys.timestamp] = ADDateEncoders.encodeTimestamp(timestamp)
+
+        return dictionary
+    }
+}

--- a/AzureData/Source/Objective-C/SwiftWrappers.swift
+++ b/AzureData/Source/Objective-C/SwiftWrappers.swift
@@ -1,0 +1,133 @@
+//
+//  SwiftUtilities.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+// MARK: - ADResourceWrapper
+
+class ADResourceWrapper: CodableResource {
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case resourceId         = "_rid"
+        case selfLink           = "_self"
+        case etag               = "_etag"
+        case timestamp          = "_ts"
+    }
+
+    static var type: String { return "" }
+    static var list: String { return "" }
+
+    var id:         String
+    var resourceId: String
+    var selfLink:   String?
+    var etag:       String?
+    var timestamp:  Date?
+    var altLink:    String?
+
+    func setEtag(to tag: String) { etag = tag }
+
+    func setAltLink(to link: String) { altLink = link }
+
+    init(_ resource: ADResource) {
+        self.id = resource.id
+        self.resourceId = resource.resourceId
+        self.selfLink = resource.selfLink
+        self.etag = resource.etag
+        self.timestamp = resource.timestamp
+        self.altLink = resource.altLink
+    }
+}
+
+// MARK: - PermissionEnabledADResourceWrapper
+
+class PermissionEnabledADResourceWrapper: CodableResource, SupportsPermissionToken {
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case resourceId         = "_rid"
+        case selfLink           = "_self"
+        case etag               = "_etag"
+        case timestamp          = "_ts"
+    }
+
+    static var type: String { return "" }
+    static var list: String { return "" }
+
+    var id:         String
+    var resourceId: String
+    var selfLink:   String?
+    var etag:       String?
+    var timestamp:  Date?
+    var altLink:    String?
+
+    func setEtag(to tag: String) { etag = tag }
+
+    func setAltLink(to link: String) { altLink = link }
+
+    init(_ resource: ADResource & ADSupportsPermissionToken) {
+        self.id = resource.id
+        self.resourceId = resource.resourceId
+        self.selfLink = resource.selfLink
+        self.etag = resource.etag
+        self.timestamp = resource.timestamp
+        self.altLink = resource.altLink
+    }
+}
+
+// MARK: - ADPermissionProviderWrapper
+
+class ADPermissionProviderWrapper: PermissionProvider {
+
+    var configuration: PermissionProviderConfiguration! {
+        get { return PermissionProviderConfiguration(unconditionallyBridgedFromObjectiveC: permissionProvider.configuration) }
+        set { permissionProvider.configuration = configuration.bridgeToObjectiveC() }
+    }
+
+    func getPermission(forCollectionWithId collectionId: String, inDatabase databaseId: String, withPermissionMode mode: PermissionMode, completion: @escaping (Response<Permission>) -> Void) {
+        permissionProvider.getPermission(forCollectionWithId: collectionId, inDatabase: databaseId, withPermissionMode: ADPermissionMode(mode)) {
+            completion(Response<Permission>(unconditionallyBridgedFromObjectiveC: $0))
+        }
+    }
+
+    func getPermission(forDocumentWithId documentId: String, inCollection collectionId: String, inDatabase databaseId: String, withPermissionMode mode: PermissionMode, completion: @escaping (Response<Permission>) -> Void) {
+        permissionProvider.getPermission(forDocumentWithId: documentId, inCollection: collectionId, inDatabase: databaseId, withPermissionMode: ADPermissionMode(mode)) {
+            completion(Response<Permission>(unconditionallyBridgedFromObjectiveC: $0))
+        }
+    }
+
+    func getPermission(forAttachmentsWithId attachmentId: String, onDocument documentId: String, inCollection collectionId: String, inDatabase databaseId: String, withPermissionMode mode: PermissionMode, completion: @escaping (Response<Permission>) -> Void) {
+        permissionProvider.getPermission(forAttachmentsWithId: attachmentId, onDocument: documentId, inCollection: collectionId, inDatabase: databaseId, withPermissionMode: ADPermissionMode(mode)) {
+            completion(Response<Permission>(unconditionallyBridgedFromObjectiveC: $0))
+        }
+    }
+
+    func getPermission(forStoredProcedureWithId storedProcedureId: String, inCollection collectionId: String, inDatabase databaseId: String, withPermissionMode mode: PermissionMode, completion: @escaping (Response<Permission>) -> Void) {
+        permissionProvider.getPermission(forStoredProcedureWithId: storedProcedureId, inCollection: collectionId, inDatabase: databaseId, withPermissionMode: ADPermissionMode(mode)) {
+            completion(Response<Permission>(unconditionallyBridgedFromObjectiveC: $0))
+        }
+    }
+
+    func getPermission(forUserDefinedFunctionWithId functionId: String, inCollection collectionId: String, inDatabase databaseId: String, withPermissionMode mode: PermissionMode, completion: @escaping (Response<Permission>) -> Void) {
+        permissionProvider.getPermission(forUserDefinedFunctionWithId: functionId, inCollection: collectionId, inDatabase: databaseId, withPermissionMode: ADPermissionMode(mode)) {
+            completion(Response<Permission>(unconditionallyBridgedFromObjectiveC: $0))
+        }
+    }
+
+    func getPermission(forTriggerWithId triggerId: String, inCollection collectionId: String, inDatabase databaseId: String, withPermissionMode mode: PermissionMode, completion: @escaping (Response<Permission>) -> Void) {
+        permissionProvider.getPermission(forTriggerWithId: triggerId, inCollection: collectionId, inDatabase: databaseId, withPermissionMode: ADPermissionMode(mode)) {
+            completion(Response<Permission>(unconditionallyBridgedFromObjectiveC: $0))
+        }
+    }
+
+    // MARK: -
+
+    private var permissionProvider: ADPermissionProvider
+
+    internal init(_ permissionProvider: ADPermissionProvider) {
+        self.permissionProvider = permissionProvider
+    }
+}

--- a/AzureData/Source/Objective-C/SwiftWrappers.swift
+++ b/AzureData/Source/Objective-C/SwiftWrappers.swift
@@ -71,43 +71,43 @@ class PermissionEnabledADResourceSwiftWrapper: CodableResource, SupportsPermissi
 class ADPermissionProviderWrapper: PermissionProvider {
 
     var configuration: PermissionProviderConfiguration! {
-        get { return PermissionProviderConfiguration(unconditionallyBridgedFromObjectiveC: permissionProvider.configuration) }
+        get { return PermissionProviderConfiguration(bridgedFromObjectiveC: permissionProvider.configuration) }
         set { permissionProvider.configuration = configuration.bridgeToObjectiveC() }
     }
 
     func getPermission(forCollectionWithId collectionId: String, inDatabase databaseId: String, withPermissionMode mode: PermissionMode, completion: @escaping (Response<Permission>) -> Void) {
         permissionProvider.getPermission(forCollectionWithId: collectionId, inDatabase: databaseId, withPermissionMode: ADPermissionMode(mode)) {
-            completion(Response<Permission>(unconditionallyBridgedFromObjectiveC: $0))
+            completion(Response<Permission>(bridgedFromObjectiveC: $0))
         }
     }
 
     func getPermission(forDocumentWithId documentId: String, inCollection collectionId: String, inDatabase databaseId: String, withPermissionMode mode: PermissionMode, completion: @escaping (Response<Permission>) -> Void) {
         permissionProvider.getPermission(forDocumentWithId: documentId, inCollection: collectionId, inDatabase: databaseId, withPermissionMode: ADPermissionMode(mode)) {
-            completion(Response<Permission>(unconditionallyBridgedFromObjectiveC: $0))
+            completion(Response<Permission>(bridgedFromObjectiveC: $0))
         }
     }
 
     func getPermission(forAttachmentsWithId attachmentId: String, onDocument documentId: String, inCollection collectionId: String, inDatabase databaseId: String, withPermissionMode mode: PermissionMode, completion: @escaping (Response<Permission>) -> Void) {
         permissionProvider.getPermission(forAttachmentsWithId: attachmentId, onDocument: documentId, inCollection: collectionId, inDatabase: databaseId, withPermissionMode: ADPermissionMode(mode)) {
-            completion(Response<Permission>(unconditionallyBridgedFromObjectiveC: $0))
+            completion(Response<Permission>(bridgedFromObjectiveC: $0))
         }
     }
 
     func getPermission(forStoredProcedureWithId storedProcedureId: String, inCollection collectionId: String, inDatabase databaseId: String, withPermissionMode mode: PermissionMode, completion: @escaping (Response<Permission>) -> Void) {
         permissionProvider.getPermission(forStoredProcedureWithId: storedProcedureId, inCollection: collectionId, inDatabase: databaseId, withPermissionMode: ADPermissionMode(mode)) {
-            completion(Response<Permission>(unconditionallyBridgedFromObjectiveC: $0))
+            completion(Response<Permission>(bridgedFromObjectiveC: $0))
         }
     }
 
     func getPermission(forUserDefinedFunctionWithId functionId: String, inCollection collectionId: String, inDatabase databaseId: String, withPermissionMode mode: PermissionMode, completion: @escaping (Response<Permission>) -> Void) {
         permissionProvider.getPermission(forUserDefinedFunctionWithId: functionId, inCollection: collectionId, inDatabase: databaseId, withPermissionMode: ADPermissionMode(mode)) {
-            completion(Response<Permission>(unconditionallyBridgedFromObjectiveC: $0))
+            completion(Response<Permission>(bridgedFromObjectiveC: $0))
         }
     }
 
     func getPermission(forTriggerWithId triggerId: String, inCollection collectionId: String, inDatabase databaseId: String, withPermissionMode mode: PermissionMode, completion: @escaping (Response<Permission>) -> Void) {
         permissionProvider.getPermission(forTriggerWithId: triggerId, inCollection: collectionId, inDatabase: databaseId, withPermissionMode: ADPermissionMode(mode)) {
-            completion(Response<Permission>(unconditionallyBridgedFromObjectiveC: $0))
+            completion(Response<Permission>(bridgedFromObjectiveC: $0))
         }
     }
 

--- a/AzureData/Source/Objective-C/SwiftWrappers.swift
+++ b/AzureData/Source/Objective-C/SwiftWrappers.swift
@@ -10,6 +10,10 @@ import Foundation
 
 // MARK: - ADResourceSwiftWrapper
 
+/// Wraps an `ADResource` and allows it to act
+/// as a `CodableResource`.
+/// - Note: Only the resource system properties
+///         will be visible.
 class ADResourceSwiftWrapper: CodableResource {
     private typealias CodingKeys = ADResourceSystemKeys
 
@@ -39,6 +43,10 @@ class ADResourceSwiftWrapper: CodableResource {
 
 // MARK: - PermissionEnabledADResourceSwiftWrapper
 
+/// Wraps an `ADResource` and allows it to act
+/// as a `CodableResource` supporting permission tokens.
+/// - Note: Only the resource system properties
+///         will be visible.
 class PermissionEnabledADResourceSwiftWrapper: CodableResource, SupportsPermissionToken {
     private typealias CodingKeys = ADResourceSystemKeys
 
@@ -68,8 +76,9 @@ class PermissionEnabledADResourceSwiftWrapper: CodableResource, SupportsPermissi
 
 // MARK: - ADPermissionProviderWrapper
 
+/// Wraps an `ADPermissionProvider` and allows it to act
+/// as a `PermissionProvider`.
 class ADPermissionProviderWrapper: PermissionProvider {
-
     var configuration: PermissionProviderConfiguration! {
         get { return PermissionProviderConfiguration(bridgedFromObjectiveC: permissionProvider.configuration) }
         set { permissionProvider.configuration = configuration.bridgeToObjectiveC() }

--- a/AzureData/Source/Objective-C/SwiftWrappers.swift
+++ b/AzureData/Source/Objective-C/SwiftWrappers.swift
@@ -8,16 +8,10 @@
 
 import Foundation
 
-// MARK: - ADResourceWrapper
+// MARK: - ADResourceSwiftWrapper
 
-class ADResourceWrapper: CodableResource {
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case resourceId         = "_rid"
-        case selfLink           = "_self"
-        case etag               = "_etag"
-        case timestamp          = "_ts"
-    }
+class ADResourceSwiftWrapper: CodableResource {
+    private typealias CodingKeys = ADResourceSystemKeys
 
     static var type: String { return "" }
     static var list: String { return "" }
@@ -43,16 +37,10 @@ class ADResourceWrapper: CodableResource {
     }
 }
 
-// MARK: - PermissionEnabledADResourceWrapper
+// MARK: - PermissionEnabledADResourceSwiftWrapper
 
-class PermissionEnabledADResourceWrapper: CodableResource, SupportsPermissionToken {
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case resourceId         = "_rid"
-        case selfLink           = "_self"
-        case etag               = "_etag"
-        case timestamp          = "_ts"
-    }
+class PermissionEnabledADResourceSwiftWrapper: CodableResource, SupportsPermissionToken {
+    private typealias CodingKeys = ADResourceSystemKeys
 
     static var type: String { return "" }
     static var list: String { return "" }

--- a/AzureData/Source/ResourceCache.swift
+++ b/AzureData/Source/ResourceCache.swift
@@ -125,20 +125,35 @@ public class ResourceCache {
     // MARK: - get
 
     static func get<T:CodableResource>(resourceAt location: ResourceLocation) -> T? {
-        
-        guard isEnabled else { return nil }
-        
+        guard let data = get(resourceAt: location) else { return nil }
+
         do {
-            if let file = try FileManager.default.file(at: ResourceOracle.getFilePath(forResourceAt: location)) {
-                
-                return try jsonDecoder.decode(T.self, from: decrypt(file))
-            }
+            return try jsonDecoder.decode(T.self, from: data)
+
         } catch {
             Log.error("❌ Cache Error [get]: " + error.localizedDescription)
+
             return nil
         }
+    }
 
-        return nil
+    static func get(resourceAt location: ResourceLocation) -> Data? {
+
+        guard isEnabled else { return nil }
+
+        do {
+
+            guard let data = try FileManager.default.file(at: ResourceOracle.getFilePath(forResourceAt: location)) else {
+                return nil
+            }
+
+            return decrypt(data)
+
+        } catch {
+            Log.error("❌ Cache Error [get]: " + error.localizedDescription)
+
+            return nil
+        }
     }
 
     static func get<T:CodableResources>(resourcesAt location: ResourceLocation, withContinuation continuation: String? = nil, as type: T.Type = T.self) -> (resources: T?, continuation: String?)? {

--- a/AzureData/Source/ResourceEncryptor.swift
+++ b/AzureData/Source/ResourceEncryptor.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@objc(ADResourceEncryptor)
 public protocol ResourceEncryptor {
     func encrypt(_ data: Data) -> Data
     func decrypt(_ data: Data) -> Data

--- a/AzureData/Source/Resources/Attachment.swift
+++ b/AzureData/Source/Resources/Attachment.swift
@@ -44,9 +44,9 @@ public struct Attachment : CodableResource, SupportsPermissionToken {
 }
 
 
-private extension Attachment {
+extension Attachment {
     
-    private enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case id
         case resourceId         = "_rid"
         case selfLink           = "_self"

--- a/AzureData/Source/Resources/Attachment.swift
+++ b/AzureData/Source/Resources/Attachment.swift
@@ -45,7 +45,6 @@ public struct Attachment : CodableResource, SupportsPermissionToken {
 
 
 extension Attachment {
-    
     enum CodingKeys: String, CodingKey {
         case id
         case resourceId         = "_rid"
@@ -54,5 +53,16 @@ extension Attachment {
         case timestamp          = "_ts"
         case contentType
         case mediaLink          = "media"
+    }
+
+    init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, contentType: String?, mediaLink: String?) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.timestamp = timestamp
+        self.altLink = altLink
+        self.contentType = contentType
+        self.mediaLink = mediaLink
     }
 }

--- a/AzureData/Source/Resources/Database.swift
+++ b/AzureData/Source/Resources/Database.swift
@@ -19,12 +19,12 @@ public struct Database : CodableResource {
     public static var type = "dbs"
     public static var list = "Databases"
 
-    public internal(set) var id:         String
-    public internal(set) var resourceId: String
-    public internal(set) var selfLink:   String?
-    public internal(set) var etag:       String?
-    public internal(set) var timestamp:  Date?
-    public internal(set) var altLink:    String? = nil
+    public private(set) var id:         String
+    public private(set) var resourceId: String
+    public private(set) var selfLink:   String?
+    public private(set) var etag:       String?
+    public private(set) var timestamp:  Date?
+    public private(set) var altLink:    String? = nil
     
     public mutating func setAltLink(to link: String) {
         self.altLink = link
@@ -34,10 +34,10 @@ public struct Database : CodableResource {
     }
 
     /// Gets the self-link for collections from the Azure Cosmos DB service.
-    public internal(set) var collectionsLink: String?
+    public private(set) var collectionsLink: String?
     
     /// Gets the self-link for users from the Azure Cosmos DB service.
-    public internal(set) var usersLink: String?
+    public private(set) var usersLink: String?
     
     
     public init (_ id: String) { self.id = id; resourceId = "" }
@@ -45,7 +45,6 @@ public struct Database : CodableResource {
 
 
 extension Database {
-    
     enum CodingKeys: String, CodingKey {
         case id
         case resourceId         = "_rid"
@@ -54,6 +53,17 @@ extension Database {
         case timestamp          = "_ts"
         case collectionsLink    = "_colls"
         case usersLink          = "_users"
+    }
+
+    init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, collectionsLink: String?, usersLink: String?) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.timestamp = timestamp
+        self.altLink = altLink
+        self.collectionsLink = collectionsLink
+        self.usersLink = usersLink
     }
 }
 

--- a/AzureData/Source/Resources/Database.swift
+++ b/AzureData/Source/Resources/Database.swift
@@ -44,9 +44,9 @@ public struct Database : CodableResource {
 }
 
 
-private extension Database {
+extension Database {
     
-    private enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case id
         case resourceId         = "_rid"
         case selfLink           = "_self"

--- a/AzureData/Source/Resources/Database.swift
+++ b/AzureData/Source/Resources/Database.swift
@@ -19,12 +19,12 @@ public struct Database : CodableResource {
     public static var type = "dbs"
     public static var list = "Databases"
 
-    public private(set) var id:         String
-    public private(set) var resourceId: String
-    public private(set) var selfLink:   String?
-    public private(set) var etag:       String?
-    public private(set) var timestamp:  Date?
-    public private(set) var altLink:    String? = nil
+    public internal(set) var id:         String
+    public internal(set) var resourceId: String
+    public internal(set) var selfLink:   String?
+    public internal(set) var etag:       String?
+    public internal(set) var timestamp:  Date?
+    public internal(set) var altLink:    String? = nil
     
     public mutating func setAltLink(to link: String) {
         self.altLink = link
@@ -34,10 +34,10 @@ public struct Database : CodableResource {
     }
 
     /// Gets the self-link for collections from the Azure Cosmos DB service.
-    public private(set) var collectionsLink: String?
+    public internal(set) var collectionsLink: String?
     
     /// Gets the self-link for users from the Azure Cosmos DB service.
-    public private(set) var usersLink: String?
+    public internal(set) var usersLink: String?
     
     
     public init (_ id: String) { self.id = id; resourceId = "" }

--- a/AzureData/Source/Resources/DictionaryDocument.swift
+++ b/AzureData/Source/Resources/DictionaryDocument.swift
@@ -24,7 +24,11 @@ public class DictionaryDocument : Document {
     
     public override init () { super.init() }
     public override init (_ id: String) { super.init(id) }
-    
+
+    internal init(data: CodableDictionary) {
+        super.init()
+        self.data = data
+    }
     
     public subscript (key: String) -> Any? {
         get { return data?[key] }

--- a/AzureData/Source/Resources/Document.swift
+++ b/AzureData/Source/Resources/Document.swift
@@ -19,12 +19,12 @@ open class Document : CodableResource, SupportsPermissionToken, CustomDebugStrin
     public static var type = "docs"
     public static var list = "Documents"
     
-    public private(set) var id:         String
-    public private(set) var resourceId: String
-    public private(set) var selfLink:   String?
-    public private(set) var etag:       String?
-    public private(set) var timestamp:  Date?
-    public private(set) var altLink:    String? = nil
+    public internal(set) var id:         String
+    public internal(set) var resourceId: String
+    public internal(set) var selfLink:   String?
+    public internal(set) var etag:       String?
+    public internal(set) var timestamp:  Date?
+    public internal(set) var altLink:    String? = nil
     
     public func setAltLink(to link: String) {
         self.altLink = link
@@ -34,7 +34,7 @@ open class Document : CodableResource, SupportsPermissionToken, CustomDebugStrin
     }
 
     /// Gets the self-link corresponding to attachments of the document from the Azure Cosmos DB service.
-    public private(set) var attachmentsLink: String?
+    public internal(set) var attachmentsLink: String?
     
     /// Gets or sets the time to live in seconds of the document in the Azure Cosmos DB service.
     public var timeToLive: Int? = nil
@@ -50,9 +50,9 @@ open class Document : CodableResource, SupportsPermissionToken, CustomDebugStrin
 }
 
 
-private extension Document {
+extension Document {
     
-    private enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case id
         case resourceId         = "_rid"
         case selfLink           = "_self"

--- a/AzureData/Source/Resources/DocumentCollection.swift
+++ b/AzureData/Source/Resources/DocumentCollection.swift
@@ -190,7 +190,6 @@ public struct DocumentCollection : CodableResource, SupportsPermissionToken {
 
 
 extension DocumentCollection {
-    
     enum CodingKeys: String, CodingKey {
         case id
         case resourceId                 = "_rid"
@@ -204,6 +203,21 @@ extension DocumentCollection {
         case storedProceduresLink       = "_sprocs"
         case triggersLink               = "_triggers"
         case userDefinedFunctionsLink   = "_udfs"
+    }
+
+    init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, conflictsLink: String?, documentsLink: String?, indexingPolicy: DocumentCollection.IndexingPolicy?, partitionKey: DocumentCollection.PartitionKeyDefinition?, storedProceduresLink: String?, triggersLink: String?, userDefinedFunctionsLink: String?) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.timestamp = timestamp
+        self.conflictsLink = conflictsLink
+        self.documentsLink = documentsLink
+        self.indexingPolicy = indexingPolicy
+        self.partitionKey = partitionKey
+        self.storedProceduresLink = storedProceduresLink
+        self.triggersLink = triggersLink
+        self.userDefinedFunctionsLink = userDefinedFunctionsLink
     }
 }
 

--- a/AzureData/Source/Resources/DocumentCollection.swift
+++ b/AzureData/Source/Resources/DocumentCollection.swift
@@ -189,9 +189,9 @@ public struct DocumentCollection : CodableResource, SupportsPermissionToken {
 }
 
 
-private extension DocumentCollection {
+extension DocumentCollection {
     
-    private enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case id
         case resourceId                 = "_rid"
         case selfLink                   = "_self"

--- a/AzureData/Source/Resources/Objective-C/ADAttachment.swift
+++ b/AzureData/Source/Resources/Objective-C/ADAttachment.swift
@@ -96,4 +96,17 @@ extension Attachment: ObjectiveCBridgeable {
             mediaLink: self.mediaLink
         )
     }
+
+    init(bridgedFromObjectiveC: ObjectiveCType) {
+        self.init(
+            id: bridgedFromObjectiveC.id,
+            resourceId: bridgedFromObjectiveC.resourceId,
+            selfLink: bridgedFromObjectiveC.selfLink,
+            etag: bridgedFromObjectiveC.etag,
+            timestamp: bridgedFromObjectiveC.timestamp,
+            altLink: bridgedFromObjectiveC.altLink,
+            contentType: bridgedFromObjectiveC.contentType,
+            mediaLink: bridgedFromObjectiveC.mediaLink
+        )
+    }
 }

--- a/AzureData/Source/Resources/Objective-C/ADAttachment.swift
+++ b/AzureData/Source/Resources/Objective-C/ADAttachment.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+/// Represents a document attachment in the Azure Cosmos DB service.
 @objc(ADAttachment)
 public class ADAttachment: NSObject, ADResource, ADSupportsPermissionToken {
     private typealias CodingKeys = Attachment.CodingKeys
@@ -30,9 +31,13 @@ public class ADAttachment: NSObject, ADResource, ADSupportsPermissionToken {
     @objc
     public let altLink: String?
 
+    /// The MIME content type of the attachment in the
+    /// Azure Cosmos DB service.
     @objc
     public let contentType: String?
 
+    /// The media link associated with the attachment content
+    /// in the Azure Cosmos DB service.
     @objc
     public let mediaLink: String?
 
@@ -51,6 +56,8 @@ public class ADAttachment: NSObject, ADResource, ADSupportsPermissionToken {
         self.contentType = contentType
         self.mediaLink = mediaLink
     }
+
+    // MARK: - ADCodable
 
     public required init?(from dictionary: NSDictionary) {
         guard let id = dictionary[CodingKeys.id] as? String else { return nil }
@@ -80,6 +87,8 @@ public class ADAttachment: NSObject, ADResource, ADSupportsPermissionToken {
         return dictionary
     }
 }
+
+// MARK: - Objective-C Bridging
 
 extension Attachment: ObjectiveCBridgeable {
     typealias ObjectiveCType = ADAttachment

--- a/AzureData/Source/Resources/Objective-C/ADAttachment.swift
+++ b/AzureData/Source/Resources/Objective-C/ADAttachment.swift
@@ -1,0 +1,99 @@
+//
+//  ADAttachment.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADAttachment)
+public class ADAttachment: NSObject, ADResource, ADSupportsPermissionToken {
+    private typealias CodingKeys = Attachment.CodingKeys
+
+    @objc
+    public let id: String
+
+    @objc
+    public let resourceId: String
+
+    @objc
+    public let selfLink: String?
+
+    @objc
+    public let etag: String?
+
+    @objc
+    public let timestamp: Date?
+
+    @objc
+    public let altLink: String?
+
+    @objc
+    public let contentType: String?
+
+    @objc
+    public let mediaLink: String?
+
+    @objc
+    public convenience init(id: String, contentType: String, url: String) {
+        self.init(id: id, resourceId: "", selfLink: nil, etag: nil, timestamp: nil, altLink: nil, contentType: contentType, mediaLink: url)
+    }
+
+    internal init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, contentType: String?, mediaLink: String?) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.timestamp = timestamp
+        self.altLink = altLink
+        self.contentType = contentType
+        self.mediaLink = mediaLink
+    }
+
+    public required init?(from dictionary: NSDictionary) {
+        guard let id = dictionary[CodingKeys.id] as? String else { return nil }
+        guard let resourceId = dictionary[CodingKeys.resourceId] as? String else { return nil }
+
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = dictionary[CodingKeys.selfLink] as? String
+        self.etag = dictionary[CodingKeys.etag] as? String
+        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.altLink = nil
+        self.contentType = dictionary[CodingKeys.contentType] as? String
+        self.mediaLink = dictionary[CodingKeys.mediaLink] as? String
+    }
+
+    public func encode() -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+
+        dictionary[CodingKeys.id] = id
+        dictionary[CodingKeys.resourceId] = resourceId
+        dictionary[CodingKeys.selfLink] = selfLink
+        dictionary[CodingKeys.etag] = etag
+        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.contentType] = contentType
+        dictionary[CodingKeys.mediaLink] = mediaLink
+
+        return dictionary
+    }
+}
+
+extension Attachment: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADAttachment
+
+    func bridgeToObjectiveC() -> ADAttachment {
+        return ADAttachment(
+            id: self.id,
+            resourceId: self.resourceId,
+            selfLink: self.selfLink,
+            etag: self.etag,
+            timestamp: self.timestamp,
+            altLink: self.altLink,
+            contentType: self.contentType,
+            mediaLink: self.mediaLink
+        )
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/ADAttachment.swift
+++ b/AzureData/Source/Resources/Objective-C/ADAttachment.swift
@@ -60,7 +60,7 @@ public class ADAttachment: NSObject, ADResource, ADSupportsPermissionToken {
         self.resourceId = resourceId
         self.selfLink = dictionary[CodingKeys.selfLink] as? String
         self.etag = dictionary[CodingKeys.etag] as? String
-        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.timestamp = ADDateEncoders.decodeTimestamp(from: dictionary[CodingKeys.timestamp])
         self.altLink = nil
         self.contentType = dictionary[CodingKeys.contentType] as? String
         self.mediaLink = dictionary[CodingKeys.mediaLink] as? String
@@ -73,7 +73,7 @@ public class ADAttachment: NSObject, ADResource, ADSupportsPermissionToken {
         dictionary[CodingKeys.resourceId] = resourceId
         dictionary[CodingKeys.selfLink] = selfLink
         dictionary[CodingKeys.etag] = etag
-        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.timestamp] = ADDateEncoders.encodeTimestamp(timestamp)
         dictionary[CodingKeys.contentType] = contentType
         dictionary[CodingKeys.mediaLink] = mediaLink
 

--- a/AzureData/Source/Resources/Objective-C/ADCodable.swift
+++ b/AzureData/Source/Resources/Objective-C/ADCodable.swift
@@ -8,8 +8,13 @@
 
 import Foundation
 
+/// A type that can convert itself in and out of a `NSDictionary`.
+/// Used for JSON serialization.
 @objc(ADCodable)
 public protocol ADCodable {
+    /// Constructs `self` from a `NSDictionary`.
     init?(from dictionary: NSDictionary)
+
+    /// Converts `self` to a `NSDictionary`.
     func encode() -> NSDictionary
 }

--- a/AzureData/Source/Resources/Objective-C/ADCodable.swift
+++ b/AzureData/Source/Resources/Objective-C/ADCodable.swift
@@ -1,0 +1,15 @@
+//
+//  ADCodable.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADCodable)
+public protocol ADCodable {
+    init?(from dictionary: NSDictionary)
+    func encode() -> NSDictionary
+}

--- a/AzureData/Source/Resources/Objective-C/ADDatabase.swift
+++ b/AzureData/Source/Resources/Objective-C/ADDatabase.swift
@@ -30,9 +30,11 @@ public class ADDatabase: NSObject, ADResource {
     @objc
     public let timestamp: Date?
 
+    /// The self-link for the collections in this database.
     @objc
     public let collectionsLink: String?
 
+    /// The self-link for the users in this database.
     @objc
     public let usersLink: String?
 
@@ -51,6 +53,8 @@ public class ADDatabase: NSObject, ADResource {
         self.collectionsLink = collectionsLink
         self.usersLink = usersLink
     }
+
+    // MARK: - ADCodable
 
     public required init?(from dictionary: NSDictionary) {
         guard let id = dictionary[CodingKeys.id] as? String else { return nil }
@@ -80,6 +84,8 @@ public class ADDatabase: NSObject, ADResource {
         return dictionary
     }
 }
+
+// MARK: - Objective-C Bridging
 
 extension Database: ObjectiveCBridgeable {
     typealias ObjectiveCType = ADDatabase

--- a/AzureData/Source/Resources/Objective-C/ADDatabase.swift
+++ b/AzureData/Source/Resources/Objective-C/ADDatabase.swift
@@ -1,0 +1,99 @@
+//
+//  ADDatabase.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADDatabase)
+public class ADDatabase: NSObject, ADResource {
+    private typealias CodingKeys = Database.CodingKeys
+
+    @objc
+    public let id: String
+
+    @objc
+    public let resourceId: String
+
+    @objc
+    public let selfLink: String?
+
+    @objc
+    public let etag: String?
+
+    @objc
+    public let altLink: String?
+
+    @objc
+    public let timestamp: Date?
+
+    @objc
+    public let collectionsLink: String?
+
+    @objc
+    public let usersLink: String?
+
+    @objc
+    public convenience init(_ id: String) {
+        self.init(id: id, resourceId: "", selfLink: nil, etag: nil, altLink: nil, timestamp: nil, collectionsLink: nil, usersLink: nil)
+    }
+
+    internal init(id: String, resourceId: String, selfLink: String?, etag: String?, altLink: String?, timestamp: Date?, collectionsLink: String?, usersLink: String?) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.altLink = altLink
+        self.timestamp = timestamp
+        self.collectionsLink = collectionsLink
+        self.usersLink = usersLink
+    }
+
+    public required init?(from dictionary: NSDictionary) {
+        guard let id = dictionary[CodingKeys.id] as? String else { return nil }
+        guard let resourceId = dictionary[CodingKeys.resourceId] as? String else { return nil }
+
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = dictionary[CodingKeys.selfLink] as? String
+        self.etag = dictionary[CodingKeys.etag] as? String
+        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.altLink = nil
+        self.collectionsLink = dictionary[CodingKeys.collectionsLink] as? String
+        self.usersLink = dictionary[CodingKeys.usersLink] as? String
+    }
+
+    public func encode() -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+
+        dictionary[CodingKeys.id] = id
+        dictionary[CodingKeys.resourceId] = resourceId
+        dictionary[CodingKeys.selfLink] = selfLink
+        dictionary[CodingKeys.etag] = etag
+        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.collectionsLink] = collectionsLink
+        dictionary[CodingKeys.usersLink] = usersLink
+
+        return dictionary
+    }
+}
+
+extension Database: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADDatabase
+
+    func bridgeToObjectiveC() -> ADDatabase {
+        return ADDatabase(
+            id: id,
+            resourceId: resourceId,
+            selfLink: selfLink,
+            etag: etag,
+            altLink: altLink,
+            timestamp: timestamp,
+            collectionsLink: collectionsLink,
+            usersLink: usersLink
+        )
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/ADDatabase.swift
+++ b/AzureData/Source/Resources/Objective-C/ADDatabase.swift
@@ -97,14 +97,16 @@ extension Database: ObjectiveCBridgeable {
         )
     }
 
-    init?(bridgedFromObjectiveC: ADDatabase) {
-        self.id = bridgedFromObjectiveC.id
-        self.resourceId = bridgedFromObjectiveC.resourceId
-        self.selfLink = bridgedFromObjectiveC.selfLink
-        self.etag = bridgedFromObjectiveC.etag
-        self.altLink = bridgedFromObjectiveC.altLink
-        self.timestamp = bridgedFromObjectiveC.timestamp
-        self.collectionsLink = bridgedFromObjectiveC.collectionsLink
-        self.usersLink = bridgedFromObjectiveC.usersLink
+    init(bridgedFromObjectiveC: ADDatabase) {
+        self.init(
+            id: bridgedFromObjectiveC.id,
+            resourceId: bridgedFromObjectiveC.resourceId,
+            selfLink: bridgedFromObjectiveC.selfLink,
+            etag: bridgedFromObjectiveC.etag,
+            timestamp: bridgedFromObjectiveC.timestamp,
+            altLink: bridgedFromObjectiveC.altLink,
+            collectionsLink: bridgedFromObjectiveC.collectionsLink,
+            usersLink: bridgedFromObjectiveC.usersLink
+        )
     }
 }

--- a/AzureData/Source/Resources/Objective-C/ADDatabase.swift
+++ b/AzureData/Source/Resources/Objective-C/ADDatabase.swift
@@ -60,7 +60,7 @@ public class ADDatabase: NSObject, ADResource {
         self.resourceId = resourceId
         self.selfLink = dictionary[CodingKeys.selfLink] as? String
         self.etag = dictionary[CodingKeys.etag] as? String
-        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.timestamp = ADDateEncoders.decodeTimestamp(from: dictionary[CodingKeys.timestamp])
         self.altLink = nil
         self.collectionsLink = dictionary[CodingKeys.collectionsLink] as? String
         self.usersLink = dictionary[CodingKeys.usersLink] as? String
@@ -73,7 +73,7 @@ public class ADDatabase: NSObject, ADResource {
         dictionary[CodingKeys.resourceId] = resourceId
         dictionary[CodingKeys.selfLink] = selfLink
         dictionary[CodingKeys.etag] = etag
-        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.timestamp] = ADDateEncoders.encodeTimestamp(timestamp)
         dictionary[CodingKeys.collectionsLink] = collectionsLink
         dictionary[CodingKeys.usersLink] = usersLink
 

--- a/AzureData/Source/Resources/Objective-C/ADDatabase.swift
+++ b/AzureData/Source/Resources/Objective-C/ADDatabase.swift
@@ -96,4 +96,15 @@ extension Database: ObjectiveCBridgeable {
             usersLink: usersLink
         )
     }
+
+    init?(bridgedFromObjectiveC: ADDatabase) {
+        self.id = bridgedFromObjectiveC.id
+        self.resourceId = bridgedFromObjectiveC.resourceId
+        self.selfLink = bridgedFromObjectiveC.selfLink
+        self.etag = bridgedFromObjectiveC.etag
+        self.altLink = bridgedFromObjectiveC.altLink
+        self.timestamp = bridgedFromObjectiveC.timestamp
+        self.collectionsLink = bridgedFromObjectiveC.collectionsLink
+        self.usersLink = bridgedFromObjectiveC.usersLink
+    }
 }

--- a/AzureData/Source/Resources/Objective-C/ADDocument.h
+++ b/AzureData/Source/Resources/Objective-C/ADDocument.h
@@ -9,13 +9,14 @@
 #ifndef ADDocument_h
 #define ADDocument_h
 
-@protocol ADResource
-@end
+@protocol ADResource;
+@protocol ADSupportsPermissionToken;
 
-@protocol ADSupportsPermissionToken
-@end
-
+#pragma clang diagnostic push
+// Ignore the 'Cannot find ADResource and ADSupportsPermissionToken protocols' warnings.
+#pragma clang diagnostic ignored "-Weverything"
 @interface ADDocument: NSObject <ADResource, ADSupportsPermissionToken>
+#pragma clang diagnostic pop
 
 @property (nonatomic, readonly, copy) NSString* _Nonnull  id;
 @property (nonatomic, readonly, copy) NSString* _Nonnull  resourceId;

--- a/AzureData/Source/Resources/Objective-C/ADDocument.h
+++ b/AzureData/Source/Resources/Objective-C/ADDocument.h
@@ -1,0 +1,35 @@
+//
+//  ADDocument.h
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+#ifndef ADDocument_h
+#define ADDocument_h
+
+@protocol ADResource
+@end
+
+@protocol ADSupportsPermissionToken
+@end
+
+@interface ADDocument: NSObject <ADResource, ADSupportsPermissionToken>
+
+@property (nonatomic, readonly, copy) NSString* _Nonnull  id;
+@property (nonatomic, readonly, copy) NSString* _Nonnull  resourceId;
+@property (nonatomic, readonly, copy) NSString* _Nullable selfLink;
+@property (nonatomic, readonly, copy) NSString* _Nullable etag;
+@property (nonatomic, readonly, copy) NSDate*   _Nullable timestamp;
+@property (nonatomic, readonly, copy) NSString* _Nullable attachmentsLink;
+@property (nonatomic, readonly, copy) NSString* _Nullable altLink;
+@property (nonatomic, readonly)       NSInteger           timeToLive;
+
+- (nonnull instancetype)initWithId:(NSString* _Nonnull)id;
+- (nullable instancetype)initFrom:(NSDictionary* _Nonnull)dictionary;
+- (NSDictionary* _Nonnull)encode;
+
+@end
+ 
+#endif /* ADDocument_h */

--- a/AzureData/Source/Resources/Objective-C/ADDocument.h
+++ b/AzureData/Source/Resources/Objective-C/ADDocument.h
@@ -9,12 +9,24 @@
 #ifndef ADDocument_h
 #define ADDocument_h
 
+// - NOTE:
+//     ADDocument has to be written in Objective-C to allow Objective-C
+//     clients to inherit from this class to create their own documents.
+//     Classes exposed from Swift cannot be inherited from in Objective-C.
+
 @protocol ADResource;
 @protocol ADSupportsPermissionToken;
 
 #pragma clang diagnostic push
 // Ignore the 'Cannot find ADResource and ADSupportsPermissionToken protocols' warnings.
 #pragma clang diagnostic ignored "-Weverything"
+
+/// Represents a document in the Azure Cosmos DB service.
+///
+/// - Remark:
+///   A document is a structured JSON document. There is no set schema for the JSON documents,
+///   and a document may contain any number of custom properties as well as an optional list of attachments.
+///   Document is an application resource and can be authorized using the master key or resource keys.
 @interface ADDocument: NSObject <ADResource, ADSupportsPermissionToken>
 #pragma clang diagnostic pop
 
@@ -23,8 +35,12 @@
 @property (nonatomic, readonly, copy) NSString* _Nullable selfLink;
 @property (nonatomic, readonly, copy) NSString* _Nullable etag;
 @property (nonatomic, readonly, copy) NSDate*   _Nullable timestamp;
-@property (nonatomic, readonly, copy) NSString* _Nullable attachmentsLink;
 @property (nonatomic, readonly, copy) NSString* _Nullable altLink;
+
+/// The self-link corresponding to attachments of the document from the Azure Cosmos DB service.
+@property (nonatomic, readonly, copy) NSString* _Nullable attachmentsLink;
+
+/// The time to live in seconds of the document in the Azure Cosmos DB service.
 @property (nonatomic, readonly)       NSInteger           timeToLive;
 
 - (nonnull instancetype)initWithId:(NSString* _Nonnull)id;

--- a/AzureData/Source/Resources/Objective-C/ADDocument.m
+++ b/AzureData/Source/Resources/Objective-C/ADDocument.m
@@ -28,6 +28,8 @@
     return self;
 }
 
+// MARK: - ADCodable
+
 - (nullable instancetype)initFrom:(NSDictionary *)dictionary {
     self = [super init];
 

--- a/AzureData/Source/Resources/Objective-C/ADDocument.m
+++ b/AzureData/Source/Resources/Objective-C/ADDocument.m
@@ -1,0 +1,68 @@
+//
+//  ADDocument.m
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "ADDocument.h"
+
+@implementation ADDocument
+
+- (nonnull instancetype)initWithId:(NSString *)id {
+    self = [super init];
+
+    if (self) {
+        _id = [id copy];
+        _resourceId = @"";
+        _selfLink = nil;
+        _etag = nil;
+        _timestamp = nil;
+        _attachmentsLink = nil;
+        _altLink = nil;
+    }
+
+    return self;
+}
+
+- (nullable instancetype)initFrom:(NSDictionary *)dictionary {
+    self = [super init];
+
+    NSString* id = [dictionary valueForKey:@"id"];
+    NSString* resourceId = [dictionary valueForKey:@"_rid"];
+
+    if (!(id && resourceId)) {
+        return nil;
+    }
+
+    if (self) {
+        _id = [id copy];
+        _resourceId = [resourceId copy];
+        _selfLink = [[dictionary valueForKey:@"_self"] copy];
+        _etag = [[dictionary valueForKey:@"_etag"] copy];
+        _timestamp = [[dictionary valueForKey:@"_ts"] copy];
+        _attachmentsLink = [[dictionary valueForKey:@"_attachments"] copy];
+    }
+
+    return self;
+}
+
+- (NSDictionary* _Nonnull)encode {
+    NSDictionary* dictionary = [[NSMutableDictionary alloc] init];
+
+    if (dictionary) {
+        [dictionary setValue:_id forKey:@"id"];
+        [dictionary setValue:_resourceId forKey:@"_rid"];
+        [dictionary setValue:_selfLink forKey:@"_self"];
+        [dictionary setValue:_etag forKey:@"_etag"];
+        [dictionary setValue:_timestamp forKey:@"_ts"];
+        [dictionary setValue:_attachmentsLink forKey:@"_attachments"];
+    }
+
+    return dictionary;
+}
+
+@end

--- a/AzureData/Source/Resources/Objective-C/ADDocument.m
+++ b/AzureData/Source/Resources/Objective-C/ADDocument.m
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-
+#import <AzureData/AzureData-Swift.h>
 #import "ADDocument.h"
 
 @implementation ADDocument
@@ -43,7 +43,7 @@
         _resourceId = [resourceId copy];
         _selfLink = [[dictionary valueForKey:@"_self"] copy];
         _etag = [[dictionary valueForKey:@"_etag"] copy];
-        _timestamp = [[dictionary valueForKey:@"_ts"] copy];
+        _timestamp = [ADDateEncoders decodeTimestampFrom:[[dictionary valueForKey:@"_ts"] copy]];
         _attachmentsLink = [[dictionary valueForKey:@"_attachments"] copy];
     }
 
@@ -58,7 +58,7 @@
         [dictionary setValue:_resourceId forKey:@"_rid"];
         [dictionary setValue:_selfLink forKey:@"_self"];
         [dictionary setValue:_etag forKey:@"_etag"];
-        [dictionary setValue:_timestamp forKey:@"_ts"];
+        [dictionary setValue:[ADDateEncoders encodeTimestamp:_timestamp] forKey:@"_ts"];
         [dictionary setValue:_attachmentsLink forKey:@"_attachments"];
     }
 

--- a/AzureData/Source/Resources/Objective-C/ADDocument.swift
+++ b/AzureData/Source/Resources/Objective-C/ADDocument.swift
@@ -11,7 +11,7 @@ import Foundation
 extension ADDocument {
     var dictionaryDocument: DictionaryDocument {
         let dictionary = self.encode() as NSDictionary
-        let dictionaryDocument = DictionaryDocument(data: CodableDictionary(unconditionallyBridgedFromObjectiveC: dictionary))
+        let dictionaryDocument = DictionaryDocument(data: CodableDictionary(bridgedFromObjectiveC: dictionary))
 
         dictionaryDocument.id = self.id
         dictionaryDocument.resourceId = self.resourceId
@@ -37,10 +37,10 @@ extension CodableDictionary: ObjectiveCBridgeable {
         return dictionary
     }
 
-    init?(bridgedFromObjectiveC: NSDictionary) {
+    init(bridgedFromObjectiveC: NSDictionary) {
         self.init(Dictionary(
                 uniqueKeysWithValues: bridgedFromObjectiveC.map { (key, value) in
-                    return (key as! String, CodableDictionaryValueType(unconditionallyBridgedFromObjectiveC: value as AnyObject).value)
+                    return (key as! String, CodableDictionaryValueType(bridgedFromObjectiveC: value as AnyObject).value)
                 }
             )
         )
@@ -75,7 +75,7 @@ extension CodableDictionaryValueType: ObjectiveCBridgeable {
         }
     }
 
-    init?(bridgedFromObjectiveC: AnyObject) {
+    init(bridgedFromObjectiveC: AnyObject) {
         switch bridgedFromObjectiveC {
         case let uuid as NSUUID:
             self.init(UUID(uuidString: uuid.uuidString)!)
@@ -92,9 +92,9 @@ extension CodableDictionaryValueType: ObjectiveCBridgeable {
         case let string as NSString:
             self.init(String(string))
         case let dict as NSDictionary:
-            self.init(CodableDictionary(unconditionallyBridgedFromObjectiveC: dict))
+            self.init(CodableDictionary(bridgedFromObjectiveC: dict))
         case let array as NSArray:
-            self.init(array.map { CodableDictionaryValueType(unconditionallyBridgedFromObjectiveC: $0 as AnyObject) })
+            self.init(array.map { CodableDictionaryValueType(bridgedFromObjectiveC: $0 as AnyObject) })
         case is NSNull:
             self.init(NSNull())
         default:

--- a/AzureData/Source/Resources/Objective-C/ADDocument.swift
+++ b/AzureData/Source/Resources/Objective-C/ADDocument.swift
@@ -8,6 +8,12 @@
 
 import Foundation
 
+/// Because `ADDocument` is an open class, we lack the necessary type
+/// information to perform a 1-to-1 bridging between `ADDocument` and
+/// `Document`. To be able to use `ADDocument` and its subclasses in the
+/// Swift world, we convert it to a `DictionaryDocument` and we bridge
+/// the internal `CodableDictionary` of the `DictionaryDocument` to
+/// `NSDictionary`.
 extension ADDocument {
     var dictionaryDocument: DictionaryDocument {
         let dictionary = self.encode() as NSDictionary
@@ -23,6 +29,8 @@ extension ADDocument {
         return dictionaryDocument
     }
 }
+
+// MARK: - Objective-C Bridging
 
 extension CodableDictionary: ObjectiveCBridgeable {
     typealias ObjectiveCType = NSDictionary

--- a/AzureData/Source/Resources/Objective-C/ADDocument.swift
+++ b/AzureData/Source/Resources/Objective-C/ADDocument.swift
@@ -1,0 +1,133 @@
+//
+//  ObjCDocument.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+extension ADDocument {
+    var dictionaryDocument: DictionaryDocument {
+        let dictionary = self.encode() as NSDictionary
+        let dictionaryDocument = DictionaryDocument(data: CodableDictionary(unconditionallyBridgedFromObjectiveC: dictionary))
+
+        dictionaryDocument.id = self.id
+        dictionaryDocument.resourceId = self.resourceId
+        dictionaryDocument.selfLink = self.selfLink
+        dictionaryDocument.etag = self.etag
+        dictionaryDocument.timestamp = self.timestamp
+        dictionaryDocument.altLink = self.altLink
+
+        return dictionaryDocument
+    }
+}
+
+extension CodableDictionary: ObjectiveCBridgeable {
+    typealias ObjectiveCType = NSDictionary
+
+    func bridgeToObjectiveC() -> NSDictionary {
+        let dictionary: NSMutableDictionary = [:]
+
+        self.forEach { (key, value) in
+            dictionary.setValue(value.bridgeToObjectiveC(), forKey: key)
+        }
+
+        return dictionary
+    }
+
+    init?(bridgedFromObjectiveC: NSDictionary) {
+        self.init(Dictionary(
+                uniqueKeysWithValues: bridgedFromObjectiveC.map { (key, value) in
+                    return (key as! String, CodableDictionaryValueType(unconditionallyBridgedFromObjectiveC: value as AnyObject).value)
+                }
+            )
+        )
+    }
+}
+
+extension CodableDictionaryValueType: ObjectiveCBridgeable {
+    typealias ObjectiveCType = AnyObject
+
+    func bridgeToObjectiveC() -> AnyObject {
+        switch self {
+        case .dictionary(let dict):
+            return dict.bridgeToObjectiveC()
+        case .array(let array):
+            return NSArray(array: array.map { $0.bridgeToObjectiveC() })
+        case .uuid(let uuid):
+            return NSUUID(uuidString: uuid.uuidString)!
+        case .bool(let value):
+            return value as AnyObject
+        case .int(let value):
+            return value as AnyObject
+        case .double(let value):
+            return value as AnyObject
+        case .float(let value):
+            return value as AnyObject
+        case .date(let value):
+            return value as AnyObject
+        case .string(let value):
+            return NSString(string: value)
+        case .empty:
+            return NSNull()
+        }
+    }
+
+    init?(bridgedFromObjectiveC: AnyObject) {
+        switch bridgedFromObjectiveC {
+        case let uuid as NSUUID:
+            self.init(UUID(uuidString: uuid.uuidString)!)
+        case let boolean as Bool:
+            self.init(boolean)
+        case let integer as Int:
+            self.init(integer)
+        case let double as Double:
+            self.init(double)
+        case let float as Float:
+            self.init(float)
+        case let date as Date:
+            self.init(date)
+        case let string as NSString:
+            self.init(String(string))
+        case let dict as NSDictionary:
+            self.init(CodableDictionary(unconditionallyBridgedFromObjectiveC: dict))
+        case let array as NSArray:
+            self.init(array.map { CodableDictionaryValueType(unconditionallyBridgedFromObjectiveC: $0 as AnyObject) })
+        case is NSNull:
+            self.init(NSNull())
+        default:
+            self.init(NSNull())
+        }
+    }
+}
+
+extension DictionaryDocument {
+    var dataMergedWithSystemKeysAndValues: [AnyHashable: Any] {
+        guard let data = self.data else { return [:] }
+        let dictionary = data.bridgeToObjectiveC().swifty
+        return dictionary.merging(systemKeysAndValues, uniquingKeysWith: { keep, _ in keep })
+    }
+
+    private var systemKeysAndValues: [AnyHashable: Any] {
+        var dictionary: [AnyHashable: Any] = [
+            Document.CodingKeys.id.rawValue: id,
+            Document.CodingKeys.resourceId.rawValue: resourceId
+        ]
+
+        if let selfLink = selfLink {
+            dictionary[Document.CodingKeys.selfLink.rawValue] = selfLink
+        }
+
+        if let etag = etag {
+            dictionary[Document.CodingKeys.etag.rawValue] = etag
+        }
+
+        if let timestamp = timestamp {
+            dictionary[Document.CodingKeys.timestamp.rawValue] = timestamp
+        }
+
+        return dictionary
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/ADOffer.swift
+++ b/AzureData/Source/Resources/Objective-C/ADOffer.swift
@@ -64,6 +64,8 @@ public class ADOffer: NSObject, ADResource {
         self.content = content
     }
 
+    // MARK: - ADCodable
+
     public required init?(from dictionary: NSDictionary) {
         guard let id = dictionary[CodingKeys.id] as? String else { return nil }
         guard let resourceId = dictionary[CodingKeys.resourceId] as? String else { return nil }
@@ -103,6 +105,8 @@ public class ADOffer: NSObject, ADResource {
         return dictionary
     }
 }
+
+// MARK: - Objective-C Bridging
 
 extension Offer: ObjectiveCBridgeable {
     typealias ObjectiveCType = ADOffer

--- a/AzureData/Source/Resources/Objective-C/ADOffer.swift
+++ b/AzureData/Source/Resources/Objective-C/ADOffer.swift
@@ -43,11 +43,14 @@ public class ADOffer: NSObject, ADResource {
     public let offerResourceId: String?
 
     @objc
+    public let content: ADOfferContent?
+
+    @objc
     public convenience init(id: String) {
-        self.init(id: id, resourceId: "", selfLink: nil, etag: nil, timestamp: nil, altLink: nil, offerType: nil, offerVersion: nil, resourceLink: nil, offerResourceId: nil)
+        self.init(id: id, resourceId: "", selfLink: nil, etag: nil, timestamp: nil, altLink: nil, offerType: nil, offerVersion: nil, resourceLink: nil, offerResourceId: nil, content: nil)
     }
 
-    internal init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, offerType: String?, offerVersion: String?, resourceLink: String?, offerResourceId: String?) {
+    internal init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, offerType: String?, offerVersion: String?, resourceLink: String?, offerResourceId: String?, content: ADOfferContent?) {
         self.id = id
         self.resourceId = resourceId
         self.selfLink = selfLink
@@ -58,6 +61,7 @@ public class ADOffer: NSObject, ADResource {
         self.offerVersion = offerVersion
         self.resourceLink = resourceLink
         self.offerResourceId = offerResourceId
+        self.content = content
     }
 
     public required init?(from dictionary: NSDictionary) {
@@ -74,6 +78,12 @@ public class ADOffer: NSObject, ADResource {
         self.offerVersion = dictionary[CodingKeys.offerVersion] as? String
         self.resourceLink = dictionary[CodingKeys.resourceLink] as? String
         self.offerResourceId = dictionary[CodingKeys.offerResourceId] as? String
+
+        if let content = dictionary[CodingKeys.content] as? NSDictionary {
+            self.content = ADOfferContent(from: content)
+        } else {
+            self.content = nil
+        }
     }
 
     public func encode() -> NSDictionary {
@@ -88,6 +98,7 @@ public class ADOffer: NSObject, ADResource {
         dictionary[CodingKeys.offerVersion] = offerVersion
         dictionary[CodingKeys.resourceLink] = resourceLink
         dictionary[CodingKeys.offerResourceId] = offerResourceId
+        dictionary[CodingKeys.content] = content?.encode()
 
         return dictionary
     }
@@ -107,7 +118,29 @@ extension Offer: ObjectiveCBridgeable {
             offerType: self.offerType,
             offerVersion: self.offerVersion,
             resourceLink: self.resourceLink,
-            offerResourceId: self.offerResourceId
+            offerResourceId: self.offerResourceId,
+            content: self.content?.bridgeToObjectiveC()
+        )
+    }
+
+    init(bridgedFromObjectiveC: ADOffer) {
+        let offerContent: OfferContent? = {
+            guard let content = bridgedFromObjectiveC.content else { return nil }
+            return OfferContent(bridgedFromObjectiveC: content)
+        }()
+
+        self.init(
+            id: bridgedFromObjectiveC.id,
+            resourceId: bridgedFromObjectiveC.resourceId,
+            selfLink: bridgedFromObjectiveC.selfLink,
+            etag: bridgedFromObjectiveC.etag,
+            timestamp: bridgedFromObjectiveC.timestamp,
+            altLink: bridgedFromObjectiveC.altLink,
+            offerType: bridgedFromObjectiveC.offerType,
+            offerVersion: bridgedFromObjectiveC.offerVersion,
+            resourceLink: bridgedFromObjectiveC.resourceLink,
+            offerResourceId: bridgedFromObjectiveC.offerResourceId,
+            content: offerContent
         )
     }
 }

--- a/AzureData/Source/Resources/Objective-C/ADOffer.swift
+++ b/AzureData/Source/Resources/Objective-C/ADOffer.swift
@@ -1,0 +1,113 @@
+//
+//  ADOffer.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADOffer)
+public class ADOffer: NSObject, ADResource {
+    private typealias CodingKeys = Offer.CodingKeys
+
+    @objc
+    public let id: String
+
+    @objc
+    public let resourceId: String
+
+    @objc
+    public let selfLink: String?
+
+    @objc
+    public let etag: String?
+
+    @objc
+    public let timestamp: Date?
+
+    @objc
+    public let altLink: String?
+
+    @objc
+    public let offerType: String?
+
+    @objc
+    public let offerVersion: String?
+
+    @objc
+    public let resourceLink: String?
+
+    @objc
+    public let offerResourceId: String?
+
+    @objc
+    public convenience init(id: String) {
+        self.init(id: id, resourceId: "", selfLink: nil, etag: nil, timestamp: nil, altLink: nil, offerType: nil, offerVersion: nil, resourceLink: nil, offerResourceId: nil)
+    }
+
+    internal init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, offerType: String?, offerVersion: String?, resourceLink: String?, offerResourceId: String?) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.timestamp = timestamp
+        self.altLink = altLink
+        self.offerType = offerType
+        self.offerVersion = offerVersion
+        self.resourceLink = resourceLink
+        self.offerResourceId = offerResourceId
+    }
+
+    public required init?(from dictionary: NSDictionary) {
+        guard let id = dictionary[CodingKeys.id] as? String else { return nil }
+        guard let resourceId = dictionary[CodingKeys.resourceId] as? String else { return nil }
+
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = dictionary[CodingKeys.selfLink] as? String
+        self.etag = dictionary[CodingKeys.etag] as? String
+        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.altLink = nil
+        self.offerType = dictionary[CodingKeys.offerType] as? String
+        self.offerVersion = dictionary[CodingKeys.offerVersion] as? String
+        self.resourceLink = dictionary[CodingKeys.resourceLink] as? String
+        self.offerResourceId = dictionary[CodingKeys.offerResourceId] as? String
+    }
+
+    public func encode() -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+
+        dictionary[CodingKeys.id] = id
+        dictionary[CodingKeys.resourceId] = resourceId
+        dictionary[CodingKeys.selfLink] = selfLink
+        dictionary[CodingKeys.etag] = etag
+        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.offerType] = offerType
+        dictionary[CodingKeys.offerVersion] = offerVersion
+        dictionary[CodingKeys.resourceLink] = resourceLink
+        dictionary[CodingKeys.offerResourceId] = offerResourceId
+
+        return dictionary
+    }
+}
+
+extension Offer: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADOffer
+
+    func bridgeToObjectiveC() -> ADOffer {
+        return ADOffer(
+            id: self.id,
+            resourceId: self.resourceId,
+            selfLink: self.selfLink,
+            etag: self.etag,
+            timestamp: self.timestamp,
+            altLink: self.altLink,
+            offerType: self.offerType,
+            offerVersion: self.offerVersion,
+            resourceLink: self.resourceLink,
+            offerResourceId: self.offerResourceId
+        )
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/ADOffer.swift
+++ b/AzureData/Source/Resources/Objective-C/ADOffer.swift
@@ -68,7 +68,7 @@ public class ADOffer: NSObject, ADResource {
         self.resourceId = resourceId
         self.selfLink = dictionary[CodingKeys.selfLink] as? String
         self.etag = dictionary[CodingKeys.etag] as? String
-        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.timestamp = ADDateEncoders.decodeTimestamp(from: dictionary[CodingKeys.timestamp])
         self.altLink = nil
         self.offerType = dictionary[CodingKeys.offerType] as? String
         self.offerVersion = dictionary[CodingKeys.offerVersion] as? String
@@ -83,7 +83,7 @@ public class ADOffer: NSObject, ADResource {
         dictionary[CodingKeys.resourceId] = resourceId
         dictionary[CodingKeys.selfLink] = selfLink
         dictionary[CodingKeys.etag] = etag
-        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.timestamp] = ADDateEncoders.encodeTimestamp(timestamp)
         dictionary[CodingKeys.offerType] = offerType
         dictionary[CodingKeys.offerVersion] = offerVersion
         dictionary[CodingKeys.resourceLink] = resourceLink

--- a/AzureData/Source/Resources/Objective-C/ADOfferContent.swift
+++ b/AzureData/Source/Resources/Objective-C/ADOfferContent.swift
@@ -23,6 +23,8 @@ public class ADOfferContent: NSObject, ADCodable {
         self.offerThroughput = offerThroughput
     }
 
+    // MARK: - ADCodable
+
     public required init?(from dictionary: NSDictionary) {
         self.offerIsRUPerMinuteThroughputEnabled = dictionary[CodingKeys.offerIsRUPerMinuteThroughputEnabled] as? Bool ?? false
         self.offerThroughput = dictionary[CodingKeys.offerThroughput] as? Int ?? 1000
@@ -37,6 +39,8 @@ public class ADOfferContent: NSObject, ADCodable {
         return dictionary
     }
 }
+
+// MARK: - Objective-C Bridging
 
 extension Offer.OfferContent: ObjectiveCBridgeable {
     typealias ObjectiveCType = ADOfferContent

--- a/AzureData/Source/Resources/Objective-C/ADOfferContent.swift
+++ b/AzureData/Source/Resources/Objective-C/ADOfferContent.swift
@@ -1,0 +1,57 @@
+//
+//  ADOfferContent.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADOfferContent)
+public class ADOfferContent: NSObject, ADCodable {
+    private enum CodingKeys: String, CodingKey {
+        case offerIsRUPerMinuteThroughputEnabled
+        case offerThroughput
+    }
+
+    public let offerIsRUPerMinuteThroughputEnabled: Bool
+    public let offerThroughput: Int
+
+    init(offerIsRUPerMinuteThroughputEnabled: Bool, offerThroughput: Int) {
+        self.offerIsRUPerMinuteThroughputEnabled = offerIsRUPerMinuteThroughputEnabled
+        self.offerThroughput = offerThroughput
+    }
+
+    public required init?(from dictionary: NSDictionary) {
+        self.offerIsRUPerMinuteThroughputEnabled = dictionary[CodingKeys.offerIsRUPerMinuteThroughputEnabled] as? Bool ?? false
+        self.offerThroughput = dictionary[CodingKeys.offerThroughput] as? Int ?? 1000
+    }
+
+    public func encode() -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+
+        dictionary[CodingKeys.offerIsRUPerMinuteThroughputEnabled] = offerIsRUPerMinuteThroughputEnabled
+        dictionary[CodingKeys.offerThroughput] = offerThroughput
+
+        return dictionary
+    }
+}
+
+extension Offer.OfferContent: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADOfferContent
+
+    func bridgeToObjectiveC() -> ADOfferContent {
+        return ADOfferContent(
+            offerIsRUPerMinuteThroughputEnabled: self.offerIsRUPerMinuteThroughputEnabled ?? false,
+            offerThroughput: self.offerThroughput
+        )
+    }
+
+    init(bridgedFromObjectiveC: ObjectiveCType) {
+        self.init(
+            offerIsRUPerMinuteThroughputEnabled: bridgedFromObjectiveC.offerIsRUPerMinuteThroughputEnabled,
+            offerThroughput: bridgedFromObjectiveC.offerThroughput
+        )
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/ADPermission.swift
+++ b/AzureData/Source/Resources/Objective-C/ADPermission.swift
@@ -65,7 +65,7 @@ public class ADPermission: NSObject, ADResource {
         self.resourceId = resourceId
         self.selfLink = dictionary[CodingKeys.selfLink] as? String
         self.etag = dictionary[CodingKeys.etag] as? String
-        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.timestamp = ADDateEncoders.decodeTimestamp(from: dictionary[CodingKeys.timestamp])
         self.altLink = nil
         self.permissionMode = ADPermissionMode(PermissionMode(rawValue: permissionMode)!)
         self.resourceLink = dictionary[CodingKeys.resourceLink] as? String
@@ -79,7 +79,7 @@ public class ADPermission: NSObject, ADResource {
         dictionary[CodingKeys.resourceId] = resourceId
         dictionary[CodingKeys.selfLink] = selfLink
         dictionary[CodingKeys.etag] = etag
-        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.timestamp] = ADDateEncoders.encodeTimestamp(timestamp)
         dictionary[CodingKeys.permissionMode] = permissionMode.permissionMode.rawValue
         dictionary[CodingKeys.resourceLink] = resourceLink
         dictionary[CodingKeys.token] = token

--- a/AzureData/Source/Resources/Objective-C/ADPermission.swift
+++ b/AzureData/Source/Resources/Objective-C/ADPermission.swift
@@ -105,15 +105,17 @@ extension Permission: ObjectiveCBridgeable {
         )
     }
 
-    init?(bridgedFromObjectiveC: ADPermission) {
-        self.id = bridgedFromObjectiveC.id
-        self.resourceId = bridgedFromObjectiveC.resourceId
-        self.selfLink = bridgedFromObjectiveC.selfLink
-        self.etag = bridgedFromObjectiveC.etag
-        self.timestamp = bridgedFromObjectiveC.timestamp
-        self.altLink = bridgedFromObjectiveC.altLink
-        self.permissionMode = bridgedFromObjectiveC.permissionMode.permissionMode
-        self.resourceLink = bridgedFromObjectiveC.resourceLink
-        self.token = bridgedFromObjectiveC.token
+    init(bridgedFromObjectiveC: ADPermission) {
+        self.init(
+            id: bridgedFromObjectiveC.id,
+            resourceId: bridgedFromObjectiveC.resourceId,
+            selfLink: bridgedFromObjectiveC.selfLink,
+            etag: bridgedFromObjectiveC.etag,
+            timestamp: bridgedFromObjectiveC.timestamp,
+            altLink: bridgedFromObjectiveC.altLink,
+            permissionMode: bridgedFromObjectiveC.permissionMode.permissionMode,
+            resourceLink: bridgedFromObjectiveC.resourceLink,
+            token: bridgedFromObjectiveC.token
+        )
     }
 }

--- a/AzureData/Source/Resources/Objective-C/ADPermission.swift
+++ b/AzureData/Source/Resources/Objective-C/ADPermission.swift
@@ -1,0 +1,119 @@
+//
+//  ADPermission.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADPermission)
+public class ADPermission: NSObject, ADResource {
+    private typealias CodingKeys = Permission.CodingKeys
+
+    @objc
+    public let id: String
+
+    @objc
+    public let resourceId: String
+
+    @objc
+    public let selfLink: String?
+
+    @objc
+    public let etag: String?
+
+    @objc
+    public let timestamp: Date?
+
+    @objc
+    public let altLink: String?
+
+    @objc
+    public let permissionMode: ADPermissionMode
+
+    @objc
+    public let resourceLink: String?
+
+    @objc
+    public let token: String?
+
+    @objc
+    public convenience init(id: String, mode: ADPermissionMode) {
+        self.init(id: id, resourceId: "", selfLink: nil, etag: nil, timestamp: nil, altLink: nil, permissionMode: mode, resourceLink: nil, token: nil)
+    }
+
+    internal init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, permissionMode: ADPermissionMode, resourceLink: String?, token: String?) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.timestamp = timestamp
+        self.altLink = altLink
+        self.permissionMode = permissionMode
+        self.resourceLink = resourceLink
+        self.token = token
+    }
+
+    public required init?(from dictionary: NSDictionary) {
+        guard let id = dictionary[CodingKeys.id] as? String else { return nil }
+        guard let resourceId = dictionary[CodingKeys.resourceId] as? String else { return nil }
+        guard let permissionMode = dictionary[CodingKeys.permissionMode] as? String else { return nil }
+
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = dictionary[CodingKeys.selfLink] as? String
+        self.etag = dictionary[CodingKeys.etag] as? String
+        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.altLink = nil
+        self.permissionMode = ADPermissionMode(PermissionMode(rawValue: permissionMode)!)
+        self.resourceLink = dictionary[CodingKeys.resourceLink] as? String
+        self.token = dictionary[CodingKeys.token] as? String
+    }
+
+    public func encode() -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+
+        dictionary[CodingKeys.id] = id
+        dictionary[CodingKeys.resourceId] = resourceId
+        dictionary[CodingKeys.selfLink] = selfLink
+        dictionary[CodingKeys.etag] = etag
+        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.permissionMode] = permissionMode.permissionMode.rawValue
+        dictionary[CodingKeys.resourceLink] = resourceLink
+        dictionary[CodingKeys.token] = token
+
+        return dictionary
+    }
+}
+
+extension Permission: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADPermission
+
+    func bridgeToObjectiveC() -> ADPermission {
+        return ADPermission(
+            id: self.id,
+            resourceId: self.resourceId,
+            selfLink: self.selfLink,
+            etag: self.etag,
+            timestamp: self.timestamp,
+            altLink: self.altLink,
+            permissionMode: ADPermissionMode(self.permissionMode),
+            resourceLink: self.resourceLink,
+            token: self.token
+        )
+    }
+
+    init?(bridgedFromObjectiveC: ADPermission) {
+        self.id = bridgedFromObjectiveC.id
+        self.resourceId = bridgedFromObjectiveC.resourceId
+        self.selfLink = bridgedFromObjectiveC.selfLink
+        self.etag = bridgedFromObjectiveC.etag
+        self.timestamp = bridgedFromObjectiveC.timestamp
+        self.altLink = bridgedFromObjectiveC.altLink
+        self.permissionMode = bridgedFromObjectiveC.permissionMode.permissionMode
+        self.resourceLink = bridgedFromObjectiveC.resourceLink
+        self.token = bridgedFromObjectiveC.token
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/ADPermission.swift
+++ b/AzureData/Source/Resources/Objective-C/ADPermission.swift
@@ -56,6 +56,8 @@ public class ADPermission: NSObject, ADResource {
         self.token = token
     }
 
+    // MARK: - ADCodable
+
     public required init?(from dictionary: NSDictionary) {
         guard let id = dictionary[CodingKeys.id] as? String else { return nil }
         guard let resourceId = dictionary[CodingKeys.resourceId] as? String else { return nil }
@@ -87,6 +89,8 @@ public class ADPermission: NSObject, ADResource {
         return dictionary
     }
 }
+
+// MARK: - Objective-C Bridging
 
 extension Permission: ObjectiveCBridgeable {
     typealias ObjectiveCType = ADPermission

--- a/AzureData/Source/Resources/Objective-C/ADPermissionMode.swift
+++ b/AzureData/Source/Resources/Objective-C/ADPermissionMode.swift
@@ -1,0 +1,38 @@
+//
+//  ADPermissionMode.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADPermissionMode)
+public enum ADPermissionMode: Int {
+    @objc(ADPermissionModeRead)
+    case read
+
+    @objc(ADPermissionModeAll)
+    case all
+
+    public var description: String {
+        switch self {
+        case .read:
+            return "Read"
+        case .all:
+            return "All"
+        }
+    }
+
+    internal init(_ permissionMode: PermissionMode) {
+        switch permissionMode {
+        case .read: self = .read
+        case .all: self = .all
+        }
+    }
+
+    internal var permissionMode: PermissionMode {
+        return PermissionMode(rawValue: description)!
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/ADPermissionMode.swift
+++ b/AzureData/Source/Resources/Objective-C/ADPermissionMode.swift
@@ -8,6 +8,11 @@
 
 import Foundation
 
+/// These are the access permissions for creating or replacing a Permission resource in the Azure Cosmos DB service.
+///
+/// - ADPermissionModeRead: All permission mode will provide the user with full access(read, insert, replace and delete)
+///         to a resource.
+/// - ADPermissionModeAll:  Read permission mode will provide the user with Read only access to a resource.
 @objc(ADPermissionMode)
 public enum ADPermissionMode: Int {
     @objc(ADPermissionModeRead)

--- a/AzureData/Source/Resources/Objective-C/ADResource.swift
+++ b/AzureData/Source/Resources/Objective-C/ADResource.swift
@@ -1,0 +1,24 @@
+//
+//  ADResource.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADResource)
+public protocol ADResource: ADCodable {
+    var id: String { get }
+
+    var resourceId: String { get }
+
+    var selfLink: String? { get }
+
+    var etag: String? { get }
+
+    var timestamp: Date? { get }
+
+    var altLink: String? { get }
+}

--- a/AzureData/Source/Resources/Objective-C/ADResource.swift
+++ b/AzureData/Source/Resources/Objective-C/ADResource.swift
@@ -8,17 +8,35 @@
 
 import Foundation
 
+/// Represents a resource type in the Azure Cosmos DB service.
+/// All Azure Cosmos DB resources, such as `ADDatabase`, `ADDocumentCollection`,
+/// and `ADDocument` implement this protocol.
 @objc(ADResource)
 public protocol ADResource: ADCodable {
+    /// The Id of the resource in the Azure Cosmos DB service.
     var id: String { get }
 
+    /// The system-generated Resource Id associated with
+    /// the resource in the Azure Cosmos DB service.
     var resourceId: String { get }
 
+    /// The self-link associated with the resource from
+    /// the Azure Cosmos DB service. The self-link is a
+    /// logical path to the resource in the Azure Cosmos DB
+    /// service made of system-generated ids (`resourceId`s).
     var selfLink: String? { get }
 
+    /// The entity tag associated with the resource from
+    /// the Azure Cosmos DB service.
     var etag: String? { get }
 
+    /// The last modified timestamp associated with the resource
+    /// in the Azure Cosmos DB service.
     var timestamp: Date? { get }
 
+    /// The alt-link associated with the resource in the
+    /// Azure Cosmos DB service. The alt-link is a logical
+    /// path to the resource in the Azure Cosmos DB service
+    /// made of user-generated ids (`id`s).
     var altLink: String? { get }
 }

--- a/AzureData/Source/Resources/Objective-C/ADResources.swift
+++ b/AzureData/Source/Resources/Objective-C/ADResources.swift
@@ -9,6 +9,7 @@
 import Foundation
 import AzureCore
 
+/// Represents a collection of resources in the Azure Cosmos DB service.
 @objc(ADResources)
 public class ADResources: NSObject {
     @objc
@@ -27,6 +28,8 @@ public class ADResources: NSObject {
         self.items = items
     }
 }
+
+// MARK: - Objective-C Bridging
 
 extension Resources: ObjectiveCBridgeable where Resources.Item: ObjectiveCBridgeable {
     typealias ObjectiveCType = ADResources

--- a/AzureData/Source/Resources/Objective-C/ADResources.swift
+++ b/AzureData/Source/Resources/Objective-C/ADResources.swift
@@ -38,4 +38,17 @@ extension Resources: ObjectiveCBridgeable where Resources.Item: ObjectiveCBridge
             items: self.items.map { $0.bridgeToObjectiveC() }
         )
     }
+
+    init(bridgedFromObjectiveC: ObjectiveCType) {
+        let items = bridgedFromObjectiveC.items.compactMap { swiftValue -> Item? in
+            guard let objectiveCValue = swiftValue as? Item.ObjectiveCType else { return nil }
+            return Item.init(bridgedFromObjectiveC: objectiveCValue)
+        }
+
+        self.init(
+            resourceId: bridgedFromObjectiveC.resourceId,
+            count: items.count,
+            items: items
+        )
+    }
 }

--- a/AzureData/Source/Resources/Objective-C/ADResources.swift
+++ b/AzureData/Source/Resources/Objective-C/ADResources.swift
@@ -1,0 +1,41 @@
+//
+//  ADResources.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+import AzureCore
+
+@objc(ADResources)
+public class ADResources: NSObject {
+    @objc
+    public let resourceId: String
+
+    @objc
+    public let count: Int
+
+    @objc
+    public let items: [AnyObject]
+
+    @objc
+    public init(resourceId: String, count: Int, items: [AnyObject]) {
+        self.resourceId = resourceId
+        self.count = count
+        self.items = items
+    }
+}
+
+extension Resources: ObjectiveCBridgeable where Resources.Item: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADResources
+
+    func bridgeToObjectiveC() -> ADResources {
+        return ADResources(
+            resourceId: self.resourceId,
+            count: self.count,
+            items: self.items.map { $0.bridgeToObjectiveC() }
+        )
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/ADResponseMetadata.swift
+++ b/AzureData/Source/Resources/Objective-C/ADResponseMetadata.swift
@@ -1,0 +1,96 @@
+//
+//  ADResponseMetadata.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+import AzureCore
+
+@objc(ADResponseMetadata)
+public class ADResponseMetadata: NSObject {
+    private var responseMetadata: ResponseMetadata
+
+    @objc
+    public var activityId: String? { return responseMetadata.activityId }
+
+    @objc
+    public var alternateContentPath: String? { return responseMetadata.alternateContentPath }
+
+    @objc
+    public var contentType: String? { return responseMetadata.contentType }
+
+    @objc
+    public var continuation: String? { return responseMetadata.continuation }
+
+    @objc
+    public var date: Date? { return responseMetadata.date }
+
+    @objc
+    public var etag: String? { return responseMetadata.etag }
+
+    @objc
+    public var itemCount: Int { return responseMetadata.itemCount ?? Int.nil }
+
+    @objc
+    public var requestCharge: Double { return responseMetadata.requestCharge ?? Double.nil }
+
+    @objc
+    public var resourceQuota: ObjCMetrics? { return ObjCMetrics(responseMetadata.resourceQuota) }
+
+    @objc
+    public var resourceUsage: ObjCMetrics? { return ObjCMetrics(responseMetadata.resourceUsage) }
+
+    @objc
+    public var retryAfter: TimeInterval { return responseMetadata.retryAfter ?? Double.nil }
+
+    @objc
+    public var schemaVersion: String? { return responseMetadata.schemaVersion }
+
+    @objc
+    public var serviceVersion: String? { return responseMetadata.serviceVersion }
+
+    @objc
+    public var sessionToken: String? { return responseMetadata.sessionToken }
+
+    internal init?(_ responseMetadata: ResponseMetadata? = nil) {
+        guard let metadata = responseMetadata else { return nil }
+        self.responseMetadata = metadata
+    }
+
+    @objc(ADMetrics)
+    public class ObjCMetrics: NSObject {
+        private var metrics: ResponseMetadata.Metrics
+
+        @objc
+        public var collections: Int { return metrics.collections ?? Int.nil }
+
+        @objc
+        public var collectionSize: Int { return metrics.collectionSize ?? Int.nil }
+
+        @objc
+        public var documents: Int { return metrics.documents ?? Int.nil }
+
+        @objc
+        public var documentSize: Int { return metrics.documentSize ?? Int.nil }
+
+        @objc
+        public var documentsSize: Int { return metrics.documentsSize ?? Int.nil }
+
+        @objc
+        public var functions: Int { return metrics.functions ?? Int.nil }
+
+        @objc
+        public var storedProcedures: Int { return metrics.storedProcedures ?? Int.nil }
+
+        @objc
+        public var triggers: Int { return metrics.triggers ?? Int.nil }
+
+        internal init?(_ metrics: ResponseMetadata.Metrics? = nil) {
+            guard let metrics = metrics else { return nil }
+            self.metrics = metrics
+        }
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/ADResponseMetadata.swift
+++ b/AzureData/Source/Resources/Objective-C/ADResponseMetadata.swift
@@ -9,48 +9,72 @@
 import Foundation
 import AzureCore
 
+/// https://docs.microsoft.com/en-us/rest/api/cosmos-db/common-cosmosdb-rest-response-headers
 @objc(ADResponseMetadata)
 public class ADResponseMetadata: NSObject {
     private var responseMetadata: ResponseMetadata
 
+    /// The unique identifier of the operation.
     @objc
     public var activityId: String? { return responseMetadata.activityId }
 
+    /// The alternate path to the resource constructed using
+    /// user-supplied IDs.
     @objc
     public var alternateContentPath: String? { return responseMetadata.alternateContentPath }
 
+    /// The Content-Type is always `application/json`.
     @objc
     public var contentType: String? { return responseMetadata.contentType }
 
+    /// Represents the intermediate state of query or read-feed
+    /// execution and is returned when there are additional
+    /// results aside from what was returned in the response.
+    /// Clients can resubmit the request with the request
+    /// header `x-ms-continuation` containing this value.
     @objc
     public var continuation: String? { return responseMetadata.continuation }
 
+    /// The date time of the response operation.
     @objc
     public var date: Date? { return responseMetadata.date }
 
+    /// The `etag` of the resource retrieved.
     @objc
     public var etag: String? { return responseMetadata.etag }
 
+    /// The number of items returned for a query or a read-feed request.
     @objc
     public var itemCount: Int { return responseMetadata.itemCount ?? Int.nil }
 
+    /// The number of request units for the operation.
     @objc
     public var requestCharge: Double { return responseMetadata.requestCharge ?? Double.nil }
 
+    /// The allotted quota for a resource in a Azure CosmosDB account.
     @objc
     public var resourceQuota: ADMetrics? { return ADMetrics(responseMetadata.resourceQuota) }
 
+    /// The current usage of a resource in a Azure CosmosDB account.
     @objc
     public var resourceUsage: ADMetrics? { return ADMetrics(responseMetadata.resourceUsage) }
 
+    /// The number of seconds to wait to retry
+    /// the operation after an initial operation
+    /// received the HTTP status code 429
+    /// and was throttled.
     @objc
     public var retryAfter: TimeInterval { return responseMetadata.retryAfter ?? Double.nil }
 
+    /// The resource schema version.
     @objc
     public var schemaVersion: String? { return responseMetadata.schemaVersion }
 
+    /// The service version number.
     @objc
     public var serviceVersion: String? { return responseMetadata.serviceVersion }
+
+    /// The session token of the request.
 
     @objc
     public var sessionToken: String? { return responseMetadata.sessionToken }
@@ -64,27 +88,35 @@ public class ADResponseMetadata: NSObject {
     public class ADMetrics: NSObject {
         private var metrics: ResponseMetadata.Metrics
 
+        /// The number of collections within an Azure CosmosDB account.
         @objc
         public var collections: Int { return metrics.collections ?? Int.nil }
 
+        /// The size of a collection in kilobytes.
         @objc
         public var collectionSize: Int { return metrics.collectionSize ?? Int.nil }
 
+        /// The number of documents within a collection.
         @objc
         public var documents: Int { return metrics.documents ?? Int.nil }
 
+        /// The size of a document within a collection.
         @objc
         public var documentSize: Int { return metrics.documentSize ?? Int.nil }
 
+        /// The size of all the documents within a collection.
         @objc
         public var documentsSize: Int { return metrics.documentsSize ?? Int.nil }
 
+        /// The number of user defined functions within a collection.
         @objc
         public var functions: Int { return metrics.functions ?? Int.nil }
 
+        /// The number of stored procedures within a collection.
         @objc
         public var storedProcedures: Int { return metrics.storedProcedures ?? Int.nil }
 
+        /// The number of triggers within a collection.
         @objc
         public var triggers: Int { return metrics.triggers ?? Int.nil }
 

--- a/AzureData/Source/Resources/Objective-C/ADResponseMetadata.swift
+++ b/AzureData/Source/Resources/Objective-C/ADResponseMetadata.swift
@@ -38,10 +38,10 @@ public class ADResponseMetadata: NSObject {
     public var requestCharge: Double { return responseMetadata.requestCharge ?? Double.nil }
 
     @objc
-    public var resourceQuota: ObjCMetrics? { return ObjCMetrics(responseMetadata.resourceQuota) }
+    public var resourceQuota: ADMetrics? { return ADMetrics(responseMetadata.resourceQuota) }
 
     @objc
-    public var resourceUsage: ObjCMetrics? { return ObjCMetrics(responseMetadata.resourceUsage) }
+    public var resourceUsage: ADMetrics? { return ADMetrics(responseMetadata.resourceUsage) }
 
     @objc
     public var retryAfter: TimeInterval { return responseMetadata.retryAfter ?? Double.nil }
@@ -61,7 +61,7 @@ public class ADResponseMetadata: NSObject {
     }
 
     @objc(ADMetrics)
-    public class ObjCMetrics: NSObject {
+    public class ADMetrics: NSObject {
         private var metrics: ResponseMetadata.Metrics
 
         @objc

--- a/AzureData/Source/Resources/Objective-C/ADStoredProcedure.swift
+++ b/AzureData/Source/Resources/Objective-C/ADStoredProcedure.swift
@@ -56,7 +56,7 @@ public class ADStoredProcedure: NSObject, ADResource, ADSupportsPermissionToken 
         self.resourceId = resourceId
         self.selfLink = dictionary[CodingKeys.selfLink] as? String
         self.etag = dictionary[CodingKeys.etag] as? String
-        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.timestamp = ADDateEncoders.decodeTimestamp(from: dictionary[CodingKeys.timestamp])
         self.altLink = nil
         self.body = dictionary[CodingKeys.body] as? String
     }
@@ -68,7 +68,7 @@ public class ADStoredProcedure: NSObject, ADResource, ADSupportsPermissionToken 
         dictionary[CodingKeys.resourceId] = resourceId
         dictionary[CodingKeys.selfLink] = selfLink
         dictionary[CodingKeys.etag] = etag
-        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.timestamp] = ADDateEncoders.encodeTimestamp(timestamp)
         dictionary[CodingKeys.body] = body
 
         return dictionary

--- a/AzureData/Source/Resources/Objective-C/ADStoredProcedure.swift
+++ b/AzureData/Source/Resources/Objective-C/ADStoredProcedure.swift
@@ -90,13 +90,15 @@ extension StoredProcedure: ObjectiveCBridgeable {
         )
     }
 
-    init?(bridgedFromObjectiveC: ADStoredProcedure) {
-        self.id = bridgedFromObjectiveC.id
-        self.resourceId = bridgedFromObjectiveC.resourceId
-        self.selfLink = bridgedFromObjectiveC.selfLink
-        self.etag = bridgedFromObjectiveC.etag
-        self.timestamp = bridgedFromObjectiveC.timestamp
-        self.altLink = bridgedFromObjectiveC.altLink
-        self.body = bridgedFromObjectiveC.body
+    init(bridgedFromObjectiveC: ADStoredProcedure) {
+        self.init(
+            id: bridgedFromObjectiveC.id,
+            resourceId: bridgedFromObjectiveC.resourceId,
+            selfLink: bridgedFromObjectiveC.selfLink,
+            etag: bridgedFromObjectiveC.etag,
+            timestamp: bridgedFromObjectiveC.timestamp,
+            altLink: bridgedFromObjectiveC.altLink,
+            body: bridgedFromObjectiveC.body
+        )
     }
 }

--- a/AzureData/Source/Resources/Objective-C/ADStoredProcedure.swift
+++ b/AzureData/Source/Resources/Objective-C/ADStoredProcedure.swift
@@ -8,6 +8,12 @@
 
 import Foundation
 
+/// Represents a stored procedure in the Azure Cosmos DB service.
+///
+/// - Remark:
+///   Azure Cosmos DB allows application logic written entirely in JavaScript to be executed directly inside
+///   the database engine under the database transaction.
+///   For additional details, refer to the server-side JavaScript API documentation.
 @objc(ADStoredProcedure)
 public class ADStoredProcedure: NSObject, ADResource, ADSupportsPermissionToken {
     private typealias CodingKeys = StoredProcedure.CodingKeys
@@ -30,6 +36,13 @@ public class ADStoredProcedure: NSObject, ADResource, ADSupportsPermissionToken 
     @objc
     public let altLink: String?
 
+    /// The body of the Azure Cosmos DB stored procedure.
+    ///
+    /// - Remark:
+    ///   Must be a valid JavaScript function.
+    ///
+    /// - Example:
+    ///   `"function () { getContext().getResponse().setBody('Hello World!'); }`
     @objc
     public let body: String?
 

--- a/AzureData/Source/Resources/Objective-C/ADStoredProcedure.swift
+++ b/AzureData/Source/Resources/Objective-C/ADStoredProcedure.swift
@@ -1,0 +1,102 @@
+//
+//  ADStoredProcedure.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADStoredProcedure)
+public class ADStoredProcedure: NSObject, ADResource, ADSupportsPermissionToken {
+    private typealias CodingKeys = StoredProcedure.CodingKeys
+
+    @objc
+    public let id: String
+
+    @objc
+    public let resourceId: String
+
+    @objc
+    public let selfLink: String?
+
+    @objc
+    public let etag: String?
+
+    @objc
+    public let timestamp: Date?
+
+    @objc
+    public let altLink: String?
+
+    @objc
+    public let body: String?
+
+    @objc
+    public convenience init(id: String, body: String) {
+        self.init(id: id, resourceId: "", selfLink: nil, etag: nil, timestamp: nil, altLink: nil, body: body)
+    }
+
+    internal init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, body: String?) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.timestamp = timestamp
+        self.altLink = altLink
+        self.body = body
+    }
+
+    public required init?(from dictionary: NSDictionary) {
+        guard let id = dictionary[CodingKeys.id] as? String else { return nil }
+        guard let resourceId = dictionary[CodingKeys.resourceId] as? String else { return nil }
+
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = dictionary[CodingKeys.selfLink] as? String
+        self.etag = dictionary[CodingKeys.etag] as? String
+        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.altLink = nil
+        self.body = dictionary[CodingKeys.body] as? String
+    }
+
+    public func encode() -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+
+        dictionary[CodingKeys.id] = id
+        dictionary[CodingKeys.resourceId] = resourceId
+        dictionary[CodingKeys.selfLink] = selfLink
+        dictionary[CodingKeys.etag] = etag
+        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.body] = body
+
+        return dictionary
+    }
+}
+
+extension StoredProcedure: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADStoredProcedure
+
+    func bridgeToObjectiveC() -> ADStoredProcedure {
+        return ADStoredProcedure(
+            id: self.id,
+            resourceId: self.resourceId,
+            selfLink: self.selfLink,
+            etag: self.etag,
+            timestamp: self.timestamp,
+            altLink: self.altLink,
+            body: self.body
+        )
+    }
+
+    init?(bridgedFromObjectiveC: ADStoredProcedure) {
+        self.id = bridgedFromObjectiveC.id
+        self.resourceId = bridgedFromObjectiveC.resourceId
+        self.selfLink = bridgedFromObjectiveC.selfLink
+        self.etag = bridgedFromObjectiveC.etag
+        self.timestamp = bridgedFromObjectiveC.timestamp
+        self.altLink = bridgedFromObjectiveC.altLink
+        self.body = bridgedFromObjectiveC.body
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/ADTrigger.swift
+++ b/AzureData/Source/Resources/Objective-C/ADTrigger.swift
@@ -127,6 +127,20 @@ extension Trigger: ObjectiveCBridgeable {
             type: self.triggerType?.bridgedToObjectiveC ?? .pre
         )
     }
+
+    init(bridgedFromObjectiveC: ADTrigger) {
+        self.init(
+            id: bridgedFromObjectiveC.id,
+            resourceId: bridgedFromObjectiveC.resourceId,
+            selfLink: bridgedFromObjectiveC.selfLink,
+            etag: bridgedFromObjectiveC.etag,
+            timestamp: bridgedFromObjectiveC.timestamp,
+            altLink: bridgedFromObjectiveC.altLink,
+            body: bridgedFromObjectiveC.body,
+            triggerOperation: TriggerOperation(bridgedFromObjectiveC: bridgedFromObjectiveC.triggerOperation),
+            triggerType: TriggerType(bridgedFromObjectiveC: bridgedFromObjectiveC.triggerType)
+        )
+    }
 }
 
 extension Trigger.TriggerOperation {

--- a/AzureData/Source/Resources/Objective-C/ADTrigger.swift
+++ b/AzureData/Source/Resources/Objective-C/ADTrigger.swift
@@ -34,13 +34,13 @@ public class ADTrigger: NSObject, ADResource, ADSupportsPermissionToken {
     public let body: String?
 
     @objc
-    public let triggerOperation: ObjCTriggerOperation
+    public let triggerOperation: ADTriggerOperation
 
     @objc
-    public let triggerType: ObjCTriggerType
+    public let triggerType: ADTriggerType
 
     @objc(ADTriggerOperation)
-    public enum ObjCTriggerOperation: Int {
+    public enum ADTriggerOperation: Int {
         @objc(ADTriggerOperationAll)
         case all
 
@@ -55,7 +55,7 @@ public class ADTrigger: NSObject, ADResource, ADSupportsPermissionToken {
     }
 
     @objc(ADTriggerType)
-    public enum ObjCTriggerType: Int {
+    public enum ADTriggerType: Int {
         @objc(ADTriggerTypePre)
         case pre
 
@@ -64,11 +64,11 @@ public class ADTrigger: NSObject, ADResource, ADSupportsPermissionToken {
     }
 
     @objc
-    public convenience init(id: String, body: String, operation: ObjCTriggerOperation, type: ObjCTriggerType) {
+    public convenience init(id: String, body: String, operation: ADTriggerOperation, type: ADTriggerType) {
         self.init(id: id, resourceId: "", selfLink: nil, etag: nil, timestamp: nil, altLink: nil, body: body, operation: operation, type: type)
     }
 
-    internal init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, body: String?, operation: ObjCTriggerOperation, type: ObjCTriggerType) {
+    internal init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, body: String?, operation: ADTriggerOperation, type: ADTriggerType) {
         self.id = id
         self.resourceId = resourceId
         self.selfLink = selfLink
@@ -130,7 +130,7 @@ extension Trigger: ObjectiveCBridgeable {
 }
 
 extension Trigger.TriggerOperation {
-    var bridgedToObjectiveC: ADTrigger.ObjCTriggerOperation {
+    var bridgedToObjectiveC: ADTrigger.ADTriggerOperation {
         switch self {
         case .all:     return .all
         case .insert:  return .insert
@@ -139,7 +139,7 @@ extension Trigger.TriggerOperation {
         }
     }
 
-    init(bridgedFromObjectiveC: ADTrigger.ObjCTriggerOperation) {
+    init(bridgedFromObjectiveC: ADTrigger.ADTriggerOperation) {
         switch bridgedFromObjectiveC {
         case .all:     self = .all
         case .insert:  self = .insert
@@ -150,14 +150,14 @@ extension Trigger.TriggerOperation {
 }
 
 extension Trigger.TriggerType {
-    var bridgedToObjectiveC: ADTrigger.ObjCTriggerType {
+    var bridgedToObjectiveC: ADTrigger.ADTriggerType {
         switch self {
         case .pre:  return .pre
         case .post: return .post
         }
     }
 
-    init(bridgedFromObjectiveC: ADTrigger.ObjCTriggerType) {
+    init(bridgedFromObjectiveC: ADTrigger.ADTriggerType) {
         switch bridgedFromObjectiveC {
         case .pre:  self = .pre
         case .post: self = .post

--- a/AzureData/Source/Resources/Objective-C/ADTrigger.swift
+++ b/AzureData/Source/Resources/Objective-C/ADTrigger.swift
@@ -8,6 +8,11 @@
 
 import Foundation
 
+/// Represents a trigger in the Azure Cosmos DB service.
+///
+/// - Remark:
+///   Azure Cosmos DB supports pre and post triggers written in JavaScript to be executed on creates, updates and deletes.
+///   For additional details, refer to the server-side JavaScript API documentation.
 @objc(ADTrigger)
 public class ADTrigger: NSObject, ADResource, ADSupportsPermissionToken {
     private typealias CodingKeys = Trigger.CodingKeys
@@ -30,15 +35,24 @@ public class ADTrigger: NSObject, ADResource, ADSupportsPermissionToken {
     @objc
     public let altLink: String?
 
+    /// The body of the trigger for the Azure Cosmos DB service.
     @objc
     public let body: String?
 
+    /// The operation the trigger is associated with for the Azure Cosmos DB service.
     @objc
     public let triggerOperation: ADTriggerOperation
 
+    /// The type of the trigger for the Azure Cosmos DB service.
     @objc
     public let triggerType: ADTriggerType
 
+    /// Specifies the operations on which a trigger should be executed in the Azure Cosmos DB service.
+    ///
+    /// - ADTriggerOperationAll:      Specifies all operations.
+    /// - ADTriggerOperationInsert:   Specifies insert operations only.
+    /// - ADTriggerOperationReplace:  Specifies replace operations only.
+    /// - ADTriggerOperationDelete:   Specifies delete operations only.
     @objc(ADTriggerOperation)
     public enum ADTriggerOperation: Int {
         @objc(ADTriggerOperationAll)
@@ -54,6 +68,10 @@ public class ADTrigger: NSObject, ADResource, ADSupportsPermissionToken {
         case delete
     }
 
+    /// Specifies the type of the trigger in the Azure Cosmos DB service.
+    ///
+    /// - ADTriggerTypePre:  Trigger should be executed after the associated operation(s).
+    /// - ADTriggerTypePost: Trigger should be executed before the associated operation(s).
     @objc(ADTriggerType)
     public enum ADTriggerType: Int {
         @objc(ADTriggerTypePre)
@@ -67,6 +85,8 @@ public class ADTrigger: NSObject, ADResource, ADSupportsPermissionToken {
     public convenience init(id: String, body: String, operation: ADTriggerOperation, type: ADTriggerType) {
         self.init(id: id, resourceId: "", selfLink: nil, etag: nil, timestamp: nil, altLink: nil, body: body, operation: operation, type: type)
     }
+
+    // MARK: - ADCodable
 
     internal init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, body: String?, operation: ADTriggerOperation, type: ADTriggerType) {
         self.id = id
@@ -110,6 +130,8 @@ public class ADTrigger: NSObject, ADResource, ADSupportsPermissionToken {
         return dictionary
     }
 }
+
+// MARK: - ObjectiveCBridging
 
 extension Trigger: ObjectiveCBridgeable {
     typealias ObjectiveCType = ADTrigger

--- a/AzureData/Source/Resources/Objective-C/ADTrigger.swift
+++ b/AzureData/Source/Resources/Objective-C/ADTrigger.swift
@@ -88,7 +88,7 @@ public class ADTrigger: NSObject, ADResource, ADSupportsPermissionToken {
         self.resourceId = resourceId
         self.selfLink = dictionary[CodingKeys.selfLink] as? String
         self.etag = dictionary[CodingKeys.etag] as? String
-        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.timestamp = ADDateEncoders.decodeTimestamp(from: dictionary[CodingKeys.timestamp])
         self.altLink = nil
         self.body = dictionary[CodingKeys.body] as? String
         self.triggerOperation = (Trigger.TriggerOperation(rawValue: dictionary[CodingKeys.triggerOperation] as? String ?? "")?.bridgedToObjectiveC) ?? .all
@@ -102,7 +102,7 @@ public class ADTrigger: NSObject, ADResource, ADSupportsPermissionToken {
         dictionary[CodingKeys.resourceId] = resourceId
         dictionary[CodingKeys.selfLink] = selfLink
         dictionary[CodingKeys.etag] = etag
-        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.timestamp] = ADDateEncoders.encodeTimestamp(timestamp)
         dictionary[CodingKeys.body] = body
         dictionary[CodingKeys.triggerOperation] = Trigger.TriggerOperation(bridgedFromObjectiveC: triggerOperation)
         dictionary[CodingKeys.triggerType] = Trigger.TriggerType(bridgedFromObjectiveC: triggerType)

--- a/AzureData/Source/Resources/Objective-C/ADTrigger.swift
+++ b/AzureData/Source/Resources/Objective-C/ADTrigger.swift
@@ -1,0 +1,166 @@
+//
+//  ADTrigger.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADTrigger)
+public class ADTrigger: NSObject, ADResource, ADSupportsPermissionToken {
+    private typealias CodingKeys = Trigger.CodingKeys
+
+    @objc
+    public let id: String
+
+    @objc
+    public let resourceId: String
+
+    @objc
+    public let selfLink: String?
+
+    @objc
+    public let etag: String?
+
+    @objc
+    public let timestamp: Date?
+
+    @objc
+    public let altLink: String?
+
+    @objc
+    public let body: String?
+
+    @objc
+    public let triggerOperation: ObjCTriggerOperation
+
+    @objc
+    public let triggerType: ObjCTriggerType
+
+    @objc(ADTriggerOperation)
+    public enum ObjCTriggerOperation: Int {
+        @objc(ADTriggerOperationAll)
+        case all
+
+        @objc(ADTriggerOperationInsert)
+        case insert
+
+        @objc(ADTriggerOperationReplace)
+        case replace
+
+        @objc(ADTriggerOperationDelete)
+        case delete
+    }
+
+    @objc(ADTriggerType)
+    public enum ObjCTriggerType: Int {
+        @objc(ADTriggerTypePre)
+        case pre
+
+        @objc(ADTriggerTypePost)
+        case post
+    }
+
+    @objc
+    public convenience init(id: String, body: String, operation: ObjCTriggerOperation, type: ObjCTriggerType) {
+        self.init(id: id, resourceId: "", selfLink: nil, etag: nil, timestamp: nil, altLink: nil, body: body, operation: operation, type: type)
+    }
+
+    internal init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, body: String?, operation: ObjCTriggerOperation, type: ObjCTriggerType) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.timestamp = timestamp
+        self.altLink = altLink
+        self.body = body
+        self.triggerOperation = operation
+        self.triggerType = type
+    }
+
+    public required init?(from dictionary: NSDictionary) {
+        guard let id = dictionary.value(forKey: Trigger.CodingKeys.id.rawValue) as? String else { return nil }
+        guard let resourceId = dictionary.value(forKey: Trigger.CodingKeys.resourceId.rawValue) as? String else { return nil }
+
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = dictionary[CodingKeys.selfLink] as? String
+        self.etag = dictionary[CodingKeys.etag] as? String
+        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.altLink = nil
+        self.body = dictionary[CodingKeys.body] as? String
+        self.triggerOperation = (Trigger.TriggerOperation(rawValue: dictionary[CodingKeys.triggerOperation] as? String ?? "")?.bridgedToObjectiveC) ?? .all
+        self.triggerType = (Trigger.TriggerType(rawValue: dictionary[CodingKeys.triggerType] as? String ?? "")?.bridgedToObjectiveC) ?? .pre
+    }
+
+    public func encode() -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+
+        dictionary[CodingKeys.id] = id
+        dictionary[CodingKeys.resourceId] = resourceId
+        dictionary[CodingKeys.selfLink] = selfLink
+        dictionary[CodingKeys.etag] = etag
+        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.body] = body
+        dictionary[CodingKeys.triggerOperation] = Trigger.TriggerOperation(bridgedFromObjectiveC: triggerOperation)
+        dictionary[CodingKeys.triggerType] = Trigger.TriggerType(bridgedFromObjectiveC: triggerType)
+
+        return dictionary
+    }
+}
+
+extension Trigger: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADTrigger
+
+    func bridgeToObjectiveC() -> ADTrigger {
+        return ADTrigger(
+            id: self.id,
+            resourceId: self.resourceId,
+            selfLink: self.selfLink,
+            etag: self.etag,
+            timestamp: self.timestamp,
+            altLink: self.altLink,
+            body: self.body,
+            operation: self.triggerOperation?.bridgedToObjectiveC ?? .all,
+            type: self.triggerType?.bridgedToObjectiveC ?? .pre
+        )
+    }
+}
+
+extension Trigger.TriggerOperation {
+    var bridgedToObjectiveC: ADTrigger.ObjCTriggerOperation {
+        switch self {
+        case .all:     return .all
+        case .insert:  return .insert
+        case .replace: return .replace
+        case .delete:  return .delete
+        }
+    }
+
+    init(bridgedFromObjectiveC: ADTrigger.ObjCTriggerOperation) {
+        switch bridgedFromObjectiveC {
+        case .all:     self = .all
+        case .insert:  self = .insert
+        case .replace: self = .replace
+        case .delete:  self = .delete
+        }
+    }
+}
+
+extension Trigger.TriggerType {
+    var bridgedToObjectiveC: ADTrigger.ObjCTriggerType {
+        switch self {
+        case .pre:  return .pre
+        case .post: return .post
+        }
+    }
+
+    init(bridgedFromObjectiveC: ADTrigger.ObjCTriggerType) {
+        switch bridgedFromObjectiveC {
+        case .pre:  self = .pre
+        case .post: self = .post
+        }
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/ADUser.swift
+++ b/AzureData/Source/Resources/Objective-C/ADUser.swift
@@ -56,7 +56,7 @@ public class ADUser: NSObject, ADResource {
         self.resourceId = resourceId
         self.selfLink = dictionary[CodingKeys.selfLink] as? String
         self.etag = dictionary[CodingKeys.etag] as? String
-        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.timestamp = ADDateEncoders.decodeTimestamp(from: dictionary[CodingKeys.timestamp])
         self.altLink = nil
         self.permissionsLink = dictionary[CodingKeys.permissionsLink] as? String
     }
@@ -68,7 +68,7 @@ public class ADUser: NSObject, ADResource {
         dictionary[CodingKeys.resourceId] = resourceId
         dictionary[CodingKeys.selfLink] = selfLink
         dictionary[CodingKeys.etag] = etag
-        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.timestamp] = ADDateEncoders.encodeTimestamp(timestamp)
         dictionary[CodingKeys.permissionsLink] = permissionsLink
 
         return dictionary

--- a/AzureData/Source/Resources/Objective-C/ADUser.swift
+++ b/AzureData/Source/Resources/Objective-C/ADUser.swift
@@ -1,0 +1,102 @@
+//
+//  ADUser.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADUser)
+public class ADUser: NSObject, ADResource {
+    private typealias CodingKeys = User.CodingKeys
+
+    @objc
+    public let id: String
+
+    @objc
+    public let resourceId: String
+
+    @objc
+    public let selfLink: String?
+
+    @objc
+    public let etag: String?
+
+    @objc
+    public let timestamp: Date?
+
+    @objc
+    public let altLink: String?
+
+    @objc
+    public let permissionsLink: String?
+
+    @objc
+    public convenience init(id: String, permissionsLink: String? = nil) {
+        self.init(id: id, resourceId: "", selfLink: nil, etag: nil, timestamp: nil, altLink: nil, permissionsLink: permissionsLink)
+    }
+
+    internal init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, permissionsLink: String?) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.timestamp = timestamp
+        self.altLink = altLink
+        self.permissionsLink = permissionsLink
+    }
+
+    public required init?(from dictionary: NSDictionary) {
+        guard let id = dictionary.value(forKey: User.CodingKeys.id.rawValue) as? String else { return nil }
+        guard let resourceId = dictionary.value(forKey: User.CodingKeys.resourceId.rawValue) as? String else { return nil }
+
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = dictionary[CodingKeys.selfLink] as? String
+        self.etag = dictionary[CodingKeys.etag] as? String
+        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.altLink = nil
+        self.permissionsLink = dictionary[CodingKeys.permissionsLink] as? String
+    }
+
+    public func encode() -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+
+        dictionary[CodingKeys.id] = id
+        dictionary[CodingKeys.resourceId] = resourceId
+        dictionary[CodingKeys.selfLink] = selfLink
+        dictionary[CodingKeys.etag] = etag
+        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.permissionsLink] = permissionsLink
+
+        return dictionary
+    }
+}
+
+extension User: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADUser
+
+    func bridgeToObjectiveC() -> ADUser {
+        return ADUser(
+            id: self.id,
+            resourceId: self.resourceId,
+            selfLink: self.selfLink,
+            etag: self.etag,
+            timestamp: self.timestamp,
+            altLink: self.altLink,
+            permissionsLink: self.permissionsLink
+        )
+    }
+
+    init?(bridgedFromObjectiveC: ADUser) {
+        self.id = bridgedFromObjectiveC.id
+        self.resourceId = bridgedFromObjectiveC.resourceId
+        self.selfLink = bridgedFromObjectiveC.selfLink
+        self.etag = bridgedFromObjectiveC.etag
+        self.timestamp = bridgedFromObjectiveC.timestamp
+        self.altLink = bridgedFromObjectiveC.altLink
+        self.permissionsLink = bridgedFromObjectiveC.permissionsLink
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/ADUser.swift
+++ b/AzureData/Source/Resources/Objective-C/ADUser.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+/// Represents a user in the Azure Cosmos DB service.
 @objc(ADUser)
 public class ADUser: NSObject, ADResource {
     private typealias CodingKeys = User.CodingKeys
@@ -30,6 +31,7 @@ public class ADUser: NSObject, ADResource {
     @objc
     public let altLink: String?
 
+    /// The self-link of the permissions associated with the user for the Azure Cosmos DB service.
     @objc
     public let permissionsLink: String?
 
@@ -47,6 +49,8 @@ public class ADUser: NSObject, ADResource {
         self.altLink = altLink
         self.permissionsLink = permissionsLink
     }
+
+    // MARK: - ADCodable
 
     public required init?(from dictionary: NSDictionary) {
         guard let id = dictionary.value(forKey: User.CodingKeys.id.rawValue) as? String else { return nil }
@@ -74,6 +78,8 @@ public class ADUser: NSObject, ADResource {
         return dictionary
     }
 }
+
+// MARK: - Objective-C Bridging
 
 extension User: ObjectiveCBridgeable {
     typealias ObjectiveCType = ADUser

--- a/AzureData/Source/Resources/Objective-C/ADUser.swift
+++ b/AzureData/Source/Resources/Objective-C/ADUser.swift
@@ -90,13 +90,15 @@ extension User: ObjectiveCBridgeable {
         )
     }
 
-    init?(bridgedFromObjectiveC: ADUser) {
-        self.id = bridgedFromObjectiveC.id
-        self.resourceId = bridgedFromObjectiveC.resourceId
-        self.selfLink = bridgedFromObjectiveC.selfLink
-        self.etag = bridgedFromObjectiveC.etag
-        self.timestamp = bridgedFromObjectiveC.timestamp
-        self.altLink = bridgedFromObjectiveC.altLink
-        self.permissionsLink = bridgedFromObjectiveC.permissionsLink
+    init(bridgedFromObjectiveC: ADUser) {
+        self.init(
+            id: bridgedFromObjectiveC.id,
+            resourceId: bridgedFromObjectiveC.resourceId,
+            selfLink: bridgedFromObjectiveC.selfLink,
+            etag: bridgedFromObjectiveC.etag,
+            timestamp: bridgedFromObjectiveC.timestamp,
+            altLink: bridgedFromObjectiveC.altLink,
+            permissionsLink: bridgedFromObjectiveC.permissionsLink
+        )
     }
 }

--- a/AzureData/Source/Resources/Objective-C/ADUserDefinedFunction.swift
+++ b/AzureData/Source/Resources/Objective-C/ADUserDefinedFunction.swift
@@ -8,6 +8,13 @@
 
 import Foundation
 
+/// Represents a user defined function in the Azure Cosmos DB service.
+///
+/// - Remark:
+///   Azure Cosmos DB supports JavaScript user defined functions (UDFs) which are stored in
+///   the database and can be used inside queries.
+///   Refer to [javascript-integration](http://azure.microsoft.com/documentation/articles/documentdb-sql-query/#javascript-integration) for how to use UDFs within queries.
+///   Refer to [udf](http://azure.microsoft.com/documentation/articles/documentdb-programming/#udf) for more details about implementing UDFs in JavaScript.
 @objc(ADUserDefinedFunction)
 public class ADUserDefinedFunction: NSObject, ADResource, ADSupportsPermissionToken {
     private typealias CodingKeys = UserDefinedFunction.CodingKeys
@@ -30,6 +37,13 @@ public class ADUserDefinedFunction: NSObject, ADResource, ADSupportsPermissionTo
     @objc
     public let altLink: String?
 
+    /// The body of the user defined function for the Azure Cosmos DB service.
+    ///
+    /// - Remark:
+    ///   This must be a valid JavaScript function
+    ///
+    /// - Example:
+    ///   `"function (input) { return input.toLowerCase(); }"`
     @objc
     public let body: String?
 
@@ -47,6 +61,8 @@ public class ADUserDefinedFunction: NSObject, ADResource, ADSupportsPermissionTo
         self.altLink = altLink
         self.body = body
     }
+
+    // MARK: - ADCodable
 
     public required init?(from dictionary: NSDictionary) {
         guard let id = dictionary[CodingKeys.id] as? String else { return nil }
@@ -74,6 +90,8 @@ public class ADUserDefinedFunction: NSObject, ADResource, ADSupportsPermissionTo
         return dictionary
     }
 }
+
+// MARK: - Objective-C Bridging
 
 extension UserDefinedFunction: ObjectiveCBridgeable {
     typealias ObjectiveCType = ADUserDefinedFunction

--- a/AzureData/Source/Resources/Objective-C/ADUserDefinedFunction.swift
+++ b/AzureData/Source/Resources/Objective-C/ADUserDefinedFunction.swift
@@ -56,7 +56,7 @@ public class ADUserDefinedFunction: NSObject, ADResource, ADSupportsPermissionTo
         self.resourceId = resourceId
         self.selfLink = dictionary[CodingKeys.selfLink] as? String
         self.etag = dictionary[CodingKeys.etag] as? String
-        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.timestamp = ADDateEncoders.decodeTimestamp(from: dictionary[CodingKeys.timestamp])
         self.altLink = nil
         self.body = dictionary[CodingKeys.body] as? String
     }
@@ -68,7 +68,7 @@ public class ADUserDefinedFunction: NSObject, ADResource, ADSupportsPermissionTo
         dictionary[CodingKeys.resourceId] = resourceId
         dictionary[CodingKeys.selfLink] = selfLink
         dictionary[CodingKeys.etag] = etag
-        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.timestamp] = ADDateEncoders.encodeTimestamp(timestamp)
         dictionary[CodingKeys.body] = body
 
         return dictionary

--- a/AzureData/Source/Resources/Objective-C/ADUserDefinedFunction.swift
+++ b/AzureData/Source/Resources/Objective-C/ADUserDefinedFunction.swift
@@ -1,0 +1,102 @@
+//
+//  ADUserDefinedFunction.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADUserDefinedFunction)
+public class ADUserDefinedFunction: NSObject, ADResource, ADSupportsPermissionToken {
+    private typealias CodingKeys = UserDefinedFunction.CodingKeys
+
+    @objc
+    public let id: String
+
+    @objc
+    public let resourceId: String
+
+    @objc
+    public let selfLink: String?
+
+    @objc
+    public let etag: String?
+
+    @objc
+    public let timestamp: Date?
+
+    @objc
+    public let altLink: String?
+
+    @objc
+    public let body: String?
+
+    @objc
+    public convenience init(id: String, body: String?) {
+        self.init(id: id, resourceId: "", selfLink: nil, etag: nil, timestamp: nil, altLink: nil, body: body)
+    }
+
+    internal init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, body: String?) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.timestamp = timestamp
+        self.altLink = altLink
+        self.body = body
+    }
+
+    public required init?(from dictionary: NSDictionary) {
+        guard let id = dictionary[CodingKeys.id] as? String else { return nil }
+        guard let resourceId = dictionary[CodingKeys.resourceId] as? String else { return nil }
+
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = dictionary[CodingKeys.selfLink] as? String
+        self.etag = dictionary[CodingKeys.etag] as? String
+        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.altLink = nil
+        self.body = dictionary[CodingKeys.body] as? String
+    }
+
+    public func encode() -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+
+        dictionary[CodingKeys.id] = id
+        dictionary[CodingKeys.resourceId] = resourceId
+        dictionary[CodingKeys.selfLink] = selfLink
+        dictionary[CodingKeys.etag] = etag
+        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.body] = body
+
+        return dictionary
+    }
+}
+
+extension UserDefinedFunction: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADUserDefinedFunction
+
+    func bridgeToObjectiveC() -> ADUserDefinedFunction {
+        return ADUserDefinedFunction(
+            id: self.id,
+            resourceId: self.resourceId,
+            selfLink: self.selfLink,
+            etag: self.etag,
+            timestamp: self.timestamp,
+            altLink: self.altLink,
+            body: self.body
+        )
+    }
+
+    init?(bridgedFromObjectiveC: ADUserDefinedFunction) {
+        self.id = bridgedFromObjectiveC.id
+        self.resourceId = bridgedFromObjectiveC.resourceId
+        self.selfLink = bridgedFromObjectiveC.selfLink
+        self.etag = bridgedFromObjectiveC.etag
+        self.timestamp = bridgedFromObjectiveC.timestamp
+        self.altLink = bridgedFromObjectiveC.altLink
+        self.body = bridgedFromObjectiveC.body
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/ADUserDefinedFunction.swift
+++ b/AzureData/Source/Resources/Objective-C/ADUserDefinedFunction.swift
@@ -90,13 +90,15 @@ extension UserDefinedFunction: ObjectiveCBridgeable {
         )
     }
 
-    init?(bridgedFromObjectiveC: ADUserDefinedFunction) {
-        self.id = bridgedFromObjectiveC.id
-        self.resourceId = bridgedFromObjectiveC.resourceId
-        self.selfLink = bridgedFromObjectiveC.selfLink
-        self.etag = bridgedFromObjectiveC.etag
-        self.timestamp = bridgedFromObjectiveC.timestamp
-        self.altLink = bridgedFromObjectiveC.altLink
-        self.body = bridgedFromObjectiveC.body
+    init(bridgedFromObjectiveC: ADUserDefinedFunction) {
+        self.init(
+            id: bridgedFromObjectiveC.id,
+            resourceId: bridgedFromObjectiveC.resourceId,
+            selfLink: bridgedFromObjectiveC.selfLink,
+            etag: bridgedFromObjectiveC.etag,
+            timestamp: bridgedFromObjectiveC.timestamp,
+            altLink: bridgedFromObjectiveC.altLink,
+            body: bridgedFromObjectiveC.body
+        )
     }
 }

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADDocumentCollection.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADDocumentCollection.swift
@@ -1,0 +1,148 @@
+//
+//  ADDocumentCollection.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADDocumentCollection)
+public class ADDocumentCollection: NSObject, ADResource, ADSupportsPermissionToken {
+    private typealias CodingKeys = DocumentCollection.CodingKeys
+
+    @objc
+    public let id: String
+
+    @objc
+    public let resourceId: String
+
+    @objc
+    public let selfLink: String?
+
+    @objc
+    public let etag: String?
+
+    @objc
+    public let timestamp: Date?
+
+    @objc
+    public let altLink: String?
+
+    @objc
+    public let conflictsLink: String?
+
+    @objc
+    public let defaultTimeToLive: Int
+
+    @objc
+    public let documentsLink: String?
+
+    @objc
+    public let storedProceduresLink: String?
+
+    @objc
+    public let triggersLink: String?
+
+    @objc
+    public let userDefinedFunctionsLink: String?
+
+    @objc
+    public let indexingPolicy: ADIndexingPolicy?
+
+    @objc
+    public let partitionKey: ADPartitionKeyDefinition?
+
+    @objc
+    public convenience init(id: String) {
+        self.init(id: id, resourceId: "", selfLink: nil, etag: nil, timestamp: nil, altLink: nil, conflictsLink: nil, defaultTimeToLive: Int.nil, documentsLink: nil, storedProceduresLink: nil, triggersLink: nil, userDefinedFunctionsLink: nil, indexingPolicy: nil, partitionKey: nil)
+    }
+
+    internal init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, conflictsLink: String?, defaultTimeToLive: Int, documentsLink: String?, storedProceduresLink: String?, triggersLink: String?, userDefinedFunctionsLink: String?, indexingPolicy: ADIndexingPolicy?, partitionKey: ADPartitionKeyDefinition?) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.timestamp = timestamp
+        self.altLink = altLink
+        self.conflictsLink = conflictsLink
+        self.defaultTimeToLive = defaultTimeToLive
+        self.documentsLink = documentsLink
+        self.storedProceduresLink = storedProceduresLink
+        self.triggersLink = triggersLink
+        self.userDefinedFunctionsLink = userDefinedFunctionsLink
+        self.indexingPolicy = indexingPolicy
+        self.partitionKey = partitionKey
+    }
+
+    public required init?(from dictionary: NSDictionary) {
+        guard let id = dictionary[CodingKeys.id] as? String else { return nil }
+        guard let resourceId = dictionary[CodingKeys.resourceId] as? String else { return nil }
+
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = dictionary[CodingKeys.selfLink] as? String
+        self.etag = dictionary[CodingKeys.etag] as? String
+        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.altLink = nil
+        self.conflictsLink = dictionary[CodingKeys.conflictsLink] as? String
+        self.defaultTimeToLive = Int.nil
+        self.documentsLink = dictionary[CodingKeys.documentsLink] as? String
+        self.storedProceduresLink = dictionary[CodingKeys.storedProceduresLink] as? String
+        self.triggersLink = dictionary[CodingKeys.triggersLink] as? String
+        self.userDefinedFunctionsLink = dictionary[CodingKeys.userDefinedFunctionsLink] as? String
+
+        if let indexingPolicy = dictionary[CodingKeys.indexingPolicy] as? NSDictionary {
+            self.indexingPolicy = ADIndexingPolicy(from: indexingPolicy)
+        } else {
+            self.indexingPolicy = nil
+        }
+
+        if let partitionKey = dictionary[CodingKeys.partitionKey] as? NSDictionary {
+            self.partitionKey = ADPartitionKeyDefinition(from: partitionKey)
+        } else {
+            self.partitionKey = nil
+        }
+    }
+
+    public func encode() -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+
+        dictionary[CodingKeys.id] = id
+        dictionary[CodingKeys.resourceId] = resourceId
+        dictionary[CodingKeys.selfLink] = selfLink
+        dictionary[CodingKeys.etag] = etag
+        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.conflictsLink] = conflictsLink
+        dictionary[CodingKeys.documentsLink] = documentsLink
+        dictionary[CodingKeys.storedProceduresLink] = storedProceduresLink
+        dictionary[CodingKeys.userDefinedFunctionsLink] = userDefinedFunctionsLink
+        dictionary[CodingKeys.indexingPolicy] = indexingPolicy?.encode()
+
+        return dictionary
+    }
+}
+
+extension DocumentCollection: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADDocumentCollection
+
+    func bridgeToObjectiveC() -> ADDocumentCollection {
+        return ADDocumentCollection(
+            id: self.id,
+            resourceId: self.resourceId,
+            selfLink: self.selfLink,
+            etag: self.etag,
+            timestamp: self.timestamp,
+            altLink: self.altLink,
+            conflictsLink: self.conflictsLink,
+            defaultTimeToLive: self.defaultTimeToLive ?? Int.nil,
+            documentsLink: self.documentsLink,
+            storedProceduresLink: self.storedProceduresLink,
+            triggersLink: self.triggersLink,
+            userDefinedFunctionsLink: self.userDefinedFunctionsLink,
+            indexingPolicy: self.indexingPolicy?.bridgeToObjectiveC(),
+            partitionKey: self.partitionKey?.bridgeToObjectiveC()
+        )
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADDocumentCollection.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADDocumentCollection.swift
@@ -84,7 +84,7 @@ public class ADDocumentCollection: NSObject, ADResource, ADSupportsPermissionTok
         self.resourceId = resourceId
         self.selfLink = dictionary[CodingKeys.selfLink] as? String
         self.etag = dictionary[CodingKeys.etag] as? String
-        self.timestamp = dictionary[CodingKeys.timestamp] as? Date
+        self.timestamp = ADDateEncoders.decodeTimestamp(from: dictionary[CodingKeys.timestamp])
         self.altLink = nil
         self.conflictsLink = dictionary[CodingKeys.conflictsLink] as? String
         self.defaultTimeToLive = Int.nil
@@ -113,7 +113,7 @@ public class ADDocumentCollection: NSObject, ADResource, ADSupportsPermissionTok
         dictionary[CodingKeys.resourceId] = resourceId
         dictionary[CodingKeys.selfLink] = selfLink
         dictionary[CodingKeys.etag] = etag
-        dictionary[CodingKeys.timestamp] = timestamp
+        dictionary[CodingKeys.timestamp] = ADDateEncoders.encodeTimestamp(timestamp)
         dictionary[CodingKeys.conflictsLink] = conflictsLink
         dictionary[CodingKeys.documentsLink] = documentsLink
         dictionary[CodingKeys.storedProceduresLink] = storedProceduresLink

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADDocumentCollection.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADDocumentCollection.swift
@@ -145,4 +145,31 @@ extension DocumentCollection: ObjectiveCBridgeable {
             partitionKey: self.partitionKey?.bridgeToObjectiveC()
         )
     }
+
+    init(bridgedFromObjectiveC: ObjectiveCType) {
+        let indexingPolicy: DocumentCollection.IndexingPolicy? = {
+            guard let policy = bridgedFromObjectiveC.indexingPolicy else { return nil }
+            return DocumentCollection.IndexingPolicy(bridgedFromObjectiveC: policy)
+        }()
+
+        let partitionKey: DocumentCollection.PartitionKeyDefinition? = {
+            guard let key = bridgedFromObjectiveC.partitionKey else { return nil }
+            return DocumentCollection.PartitionKeyDefinition(bridgedFromObjectiveC: key)
+        }()
+
+        self.init(
+            id: bridgedFromObjectiveC.id,
+            resourceId: bridgedFromObjectiveC.resourceId,
+            selfLink: bridgedFromObjectiveC.selfLink,
+            etag: bridgedFromObjectiveC.etag,
+            timestamp: bridgedFromObjectiveC.timestamp,
+            conflictsLink: bridgedFromObjectiveC.conflictsLink,
+            documentsLink: bridgedFromObjectiveC.documentsLink,
+            indexingPolicy: indexingPolicy,
+            partitionKey: partitionKey,
+            storedProceduresLink: bridgedFromObjectiveC.storedProceduresLink,
+            triggersLink: bridgedFromObjectiveC.triggersLink,
+            userDefinedFunctionsLink: bridgedFromObjectiveC.userDefinedFunctionsLink
+        )
+    }
 }

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADDocumentCollection.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADDocumentCollection.swift
@@ -8,6 +8,14 @@
 
 import Foundation
 
+/// Represents a document collection in the Azure Cosmos DB service.
+/// A collection is a named logical container for documents.
+///
+/// - Remark:
+///   A database may contain zero or more named collections and each collection consists of zero or more JSON documents.
+///   Being schema-free, the documents in a collection do not need to share the same structure or fields.
+///   Since collections are application resources, they can be authorized using either the master key or resource keys.
+///   Refer to [collections](http://azure.microsoft.com/documentation/articles/documentdb-resources/#collections) for more details on collections.
 @objc(ADDocumentCollection)
 public class ADDocumentCollection: NSObject, ADResource, ADSupportsPermissionToken {
     private typealias CodingKeys = DocumentCollection.CodingKeys
@@ -30,27 +38,35 @@ public class ADDocumentCollection: NSObject, ADResource, ADSupportsPermissionTok
     @objc
     public let altLink: String?
 
+    /// The self-link for conflicts in this collection from the Azure Cosmos DB service.
     @objc
     public let conflictsLink: String?
 
+    /// The default time to live in seconds for documents in a collection from the Azure Cosmos DB service.
     @objc
     public let defaultTimeToLive: Int
 
+    /// The self-link for documents in a collection from the Azure Cosmos DB service.
     @objc
     public let documentsLink: String?
 
+    /// The self-link for stored procedures in a collection from the Azure Cosmos DB service.
     @objc
     public let storedProceduresLink: String?
 
+    /// The self-link for triggers in a collection from the Azure Cosmos DB service.
     @objc
     public let triggersLink: String?
 
+    /// The self-link for user defined functions in a collection from the Azure Cosmos DB service.
     @objc
     public let userDefinedFunctionsLink: String?
 
+    /// The `ADIndexingPolicy` associated with the collection from the Azure Cosmos DB service.
     @objc
     public let indexingPolicy: ADIndexingPolicy?
 
+    /// The `PartitionKeyDefinition` object associated with the collection in the Azure Cosmos DB service.
     @objc
     public let partitionKey: ADPartitionKeyDefinition?
 
@@ -75,6 +91,8 @@ public class ADDocumentCollection: NSObject, ADResource, ADSupportsPermissionTok
         self.indexingPolicy = indexingPolicy
         self.partitionKey = partitionKey
     }
+
+    // MARK: - ADCodable
 
     public required init?(from dictionary: NSDictionary) {
         guard let id = dictionary[CodingKeys.id] as? String else { return nil }
@@ -123,6 +141,8 @@ public class ADDocumentCollection: NSObject, ADResource, ADSupportsPermissionTok
         return dictionary
     }
 }
+
+// MARK: - Objective-C Bridging
 
 extension DocumentCollection: ObjectiveCBridgeable {
     typealias ObjectiveCType = ADDocumentCollection

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADExcludedPath.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADExcludedPath.swift
@@ -41,7 +41,7 @@ extension DocumentCollection.IndexingPolicy.ExcludedPath: ObjectiveCBridgeable {
         return ADExcludedPath(path: self.path)
     }
 
-    init?(bridgedFromObjectiveC: ADExcludedPath) {
+    init(bridgedFromObjectiveC: ADExcludedPath) {
         self.init(path: bridgedFromObjectiveC.path)
     }
 }

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADExcludedPath.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADExcludedPath.swift
@@ -1,0 +1,47 @@
+//
+//  ADExcludedPath.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADExcludedPath)
+public class ADExcludedPath: NSObject, ADCodable {
+    private enum CodingKeys: String, CodingKey {
+        case path
+    }
+
+    @objc
+    public let path: String?
+
+    @objc
+    public init(path: String?) {
+        self.path = path
+    }
+
+    public required init?(from dictionary: NSDictionary) {
+        self.path = dictionary[CodingKeys.path] as? String
+    }
+
+    public func encode() -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+        dictionary[CodingKeys.path] = path
+
+        return dictionary
+    }
+}
+
+extension DocumentCollection.IndexingPolicy.ExcludedPath: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADExcludedPath
+
+    func bridgeToObjectiveC() -> ADExcludedPath {
+        return ADExcludedPath(path: self.path)
+    }
+
+    init?(bridgedFromObjectiveC: ADExcludedPath) {
+        self.init(path: bridgedFromObjectiveC.path)
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADExcludedPath.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADExcludedPath.swift
@@ -8,12 +8,14 @@
 
 import Foundation
 
+/// Specifies a path within a JSON document to be excluded while indexing data for the Azure Cosmos DB service.
 @objc(ADExcludedPath)
 public class ADExcludedPath: NSObject, ADCodable {
     private enum CodingKeys: String, CodingKey {
         case path
     }
 
+    /// The path to be excluded from indexing in the Azure Cosmos DB service.
     @objc
     public let path: String?
 
@@ -21,6 +23,8 @@ public class ADExcludedPath: NSObject, ADCodable {
     public init(path: String?) {
         self.path = path
     }
+
+    // MARK: - ADCodable
 
     public required init?(from dictionary: NSDictionary) {
         self.path = dictionary[CodingKeys.path] as? String
@@ -33,6 +37,8 @@ public class ADExcludedPath: NSObject, ADCodable {
         return dictionary
     }
 }
+
+// MARK: - Objective-C Bridging
 
 extension DocumentCollection.IndexingPolicy.ExcludedPath: ObjectiveCBridgeable {
     typealias ObjectiveCType = ADExcludedPath

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIncludedPath.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIncludedPath.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+/// Specifies a path within a JSON document to be included while indexing data in the Azure Cosmos DB service.
 @objc(ADIncludedPath)
 public class ADIncludedPath: NSObject, ADCodable {
     private enum CodingKeys: String, CodingKey {
@@ -15,9 +16,12 @@ public class ADIncludedPath: NSObject, ADCodable {
         case indexes
     }
 
+    /// The path to be indexed in the Azure Cosmos DB service.
     @objc
     public let path: String?
 
+    /// The collection of `ADIndex` objects to be applied for this included path in
+    /// the Azure Cosmos DB service.
     @objc
     public let indexes: [ADIndex]
 
@@ -26,6 +30,8 @@ public class ADIncludedPath: NSObject, ADCodable {
         self.path = path
         self.indexes = indexes
     }
+
+    // MARK: - ADCodable
 
     public required init?(from dictionary: NSDictionary) {
         self.path = dictionary[CodingKeys.path] as? String
@@ -46,6 +52,8 @@ public class ADIncludedPath: NSObject, ADCodable {
         return dictionary
     }
 }
+
+// MARK: - Objective-C Bridging
 
 extension DocumentCollection.IndexingPolicy.IncludedPath: ObjectiveCBridgeable {
     typealias ObjectiveCType = ADIncludedPath

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIncludedPath.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIncludedPath.swift
@@ -55,7 +55,7 @@ extension DocumentCollection.IndexingPolicy.IncludedPath: ObjectiveCBridgeable {
         return ADIncludedPath(path: self.path, indexes: self.indexes.map { $0.bridgeToObjectiveC() })
     }
 
-    init?(bridgedFromObjectiveC: ADIncludedPath) {
+    init(bridgedFromObjectiveC: ADIncludedPath) {
         self.init(
             path: bridgedFromObjectiveC.path,
             indexes: bridgedFromObjectiveC.indexes.compactMap { SwiftType.Index(bridgedFromObjectiveC: $0) }

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIncludedPath.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIncludedPath.swift
@@ -1,0 +1,64 @@
+//
+//  ADIncludedPath.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADIncludedPath)
+public class ADIncludedPath: NSObject, ADCodable {
+    private enum CodingKeys: String, CodingKey {
+        case path
+        case indexes
+    }
+
+    @objc
+    public let path: String?
+
+    @objc
+    public let indexes: [ADIndex]
+
+    @objc
+    public init(path: String?, indexes: [ADIndex]) {
+        self.path = path
+        self.indexes = indexes
+    }
+
+    public required init?(from dictionary: NSDictionary) {
+        self.path = dictionary[CodingKeys.path] as? String
+
+        if let indexes = dictionary[CodingKeys.indexes] as? [NSDictionary] {
+            self.indexes = indexes.compactMap { ADIndex(from: $0) }
+        } else {
+            self.indexes = []
+        }
+    }
+
+    public func encode() -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+
+        dictionary[CodingKeys.path] = path
+        dictionary[CodingKeys.indexes] = indexes.map { $0.encode() }
+
+        return dictionary
+    }
+}
+
+extension DocumentCollection.IndexingPolicy.IncludedPath: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADIncludedPath
+    typealias SwiftType = DocumentCollection.IndexingPolicy.IncludedPath
+
+    func bridgeToObjectiveC() -> ADIncludedPath {
+        return ADIncludedPath(path: self.path, indexes: self.indexes.map { $0.bridgeToObjectiveC() })
+    }
+
+    init?(bridgedFromObjectiveC: ADIncludedPath) {
+        self.init(
+            path: bridgedFromObjectiveC.path,
+            indexes: bridgedFromObjectiveC.indexes.compactMap { SwiftType.Index(bridgedFromObjectiveC: $0) }
+        )
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndex.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndex.swift
@@ -1,0 +1,89 @@
+//
+//  ADIndex.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADIndex)
+public class ADIndex: NSObject, ADCodable {
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case dataType
+        case precision
+    }
+
+    private typealias SwiftType = DocumentCollection.IndexingPolicy.IncludedPath.Index
+
+    @objc
+    public let kind: ADIndexKind
+
+    @objc
+    public let dataType: ADIndexDataType
+
+    @objc
+    public let precision: Int16
+
+    internal init(kind: ADIndexKind, dataType: ADIndexDataType, precision: Int16) {
+        self.kind = kind
+        self.dataType = dataType
+        self.precision = precision
+    }
+
+    public static func hash(withDataType dataType: ADIndexDataType, andPrecision precision: Int16) -> ADIndex {
+        return ADIndex(kind: .hash, dataType: dataType, precision: precision)
+    }
+
+    public static func range(withDataType dataType: ADIndexDataType, andPrecision precision: Int16) -> ADIndex {
+        return ADIndex(kind: .range, dataType: dataType, precision: precision)
+    }
+
+    public static func spatial(withDataType dataType: ADIndexDataType) -> ADIndex {
+        return ADIndex(kind: .spatial, dataType: dataType, precision: Int16.nil)
+    }
+
+    public required init?(from dictionary: NSDictionary) {
+        guard let kind = dictionary[CodingKeys.kind] as? String else { return nil }
+        guard let dataType = dictionary[CodingKeys.dataType] as? String else { return nil }
+
+        self.kind = SwiftType.IndexKind(rawValue: kind)!.bridgedToObjectiveC
+        self.dataType = SwiftType.DataType(rawValue: dataType)!.bridgedToObjectiveC
+        self.precision = dictionary[CodingKeys.precision] as! Int16
+    }
+
+    public func encode() -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+
+        dictionary[CodingKeys.kind] = SwiftType.IndexKind(bridgedFromObjectiveC: kind).rawValue
+        dictionary[CodingKeys.dataType] = SwiftType.DataType(bridgedFromObjectiveC: dataType).rawValue
+
+        if precision != Int16.nil {
+            dictionary[CodingKeys.precision] = precision
+        }
+
+        return dictionary
+    }
+}
+
+extension DocumentCollection.IndexingPolicy.IncludedPath.Index: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADIndex
+    typealias SwiftType = DocumentCollection.IndexingPolicy.IncludedPath.Index
+
+    func bridgeToObjectiveC() -> ADIndex {
+        let kind = self.kind!.bridgedToObjectiveC
+        let dataType = self.dataType!.bridgedToObjectiveC
+
+        return ADIndex(kind: kind, dataType: dataType, precision: precision ?? Int16.nil)
+    }
+
+    init?(bridgedFromObjectiveC: ADIndex) {
+        let kind = SwiftType.IndexKind(bridgedFromObjectiveC: bridgedFromObjectiveC.kind)
+        let dataType = SwiftType.DataType(bridgedFromObjectiveC: bridgedFromObjectiveC.dataType)
+        let precision = bridgedFromObjectiveC.precision
+
+        self.init(kind: kind, dataType: dataType, precision: precision)
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndex.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndex.swift
@@ -79,7 +79,7 @@ extension DocumentCollection.IndexingPolicy.IncludedPath.Index: ObjectiveCBridge
         return ADIndex(kind: kind, dataType: dataType, precision: precision ?? Int16.nil)
     }
 
-    init?(bridgedFromObjectiveC: ADIndex) {
+    init(bridgedFromObjectiveC: ADIndex) {
         let kind = SwiftType.IndexKind(bridgedFromObjectiveC: bridgedFromObjectiveC.kind)
         let dataType = SwiftType.DataType(bridgedFromObjectiveC: bridgedFromObjectiveC.dataType)
         let precision = bridgedFromObjectiveC.precision

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndex.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndex.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+/// Class representing `IndexingPolicy` `Indexes` in the Azure Cosmos DB service,
 @objc(ADIndex)
 public class ADIndex: NSObject, ADCodable {
     private enum CodingKeys: String, CodingKey {
@@ -18,12 +19,15 @@ public class ADIndex: NSObject, ADCodable {
 
     private typealias SwiftType = DocumentCollection.IndexingPolicy.IncludedPath.Index
 
+    /// The kind of indexing to be applied in the Azure Cosmos DB service.
     @objc
     public let kind: ADIndexKind
 
+    /// The target data type for the index path specification.
     @objc
     public let dataType: ADIndexDataType
 
+    /// The precision to be used for the data type associated with this index.
     @objc
     public let precision: Int16
 
@@ -33,17 +37,25 @@ public class ADIndex: NSObject, ADCodable {
         self.precision = precision
     }
 
+    /// Returns a hash index with the specified data type (and precision) for
+    /// the Azure Cosmos DB service.
     public static func hash(withDataType dataType: ADIndexDataType, andPrecision precision: Int16) -> ADIndex {
         return ADIndex(kind: .hash, dataType: dataType, precision: precision)
     }
 
+    /// Returns a range index with the specified data type (and precision) for
+    /// the Azure Cosmos DB service.
     public static func range(withDataType dataType: ADIndexDataType, andPrecision precision: Int16) -> ADIndex {
         return ADIndex(kind: .range, dataType: dataType, precision: precision)
     }
 
+    /// Returns a spatial index with the specified data type for
+    /// the Azure Cosmos DB service.
     public static func spatial(withDataType dataType: ADIndexDataType) -> ADIndex {
         return ADIndex(kind: .spatial, dataType: dataType, precision: Int16.nil)
     }
+
+    // MARK: - ADCodable
 
     public required init?(from dictionary: NSDictionary) {
         guard let kind = dictionary[CodingKeys.kind] as? String else { return nil }
@@ -67,6 +79,8 @@ public class ADIndex: NSObject, ADCodable {
         return dictionary
     }
 }
+
+// MARK: - Objective-C Bridging
 
 extension DocumentCollection.IndexingPolicy.IncludedPath.Index: ObjectiveCBridgeable {
     typealias ObjectiveCType = ADIndex

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexDataType.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexDataType.swift
@@ -1,0 +1,49 @@
+//
+//  ADIndexDataType.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADIndexDataType)
+public enum ADIndexDataType: Int {
+    @objc(ADIndexDataTypeLineString)
+    case lineString
+
+    @objc(ADIndexDataTypeNumber)
+    case number
+
+    @objc(ADIndexDataTypePoint)
+    case point
+
+    @objc(ADIndexDataTypePolygon)
+    case polygon
+
+    @objc(ADIndexDataTypeString)
+    case string
+}
+
+extension DocumentCollection.IndexingPolicy.IncludedPath.Index.DataType {
+    var bridgedToObjectiveC: ADIndexDataType {
+        switch self {
+        case .lineString: return .lineString
+        case .number:     return .number
+        case .point:      return .point
+        case .polygon:    return .polygon
+        case .string:     return .string
+        }
+    }
+
+    init(bridgedFromObjectiveC: ADIndexDataType) {
+        switch bridgedFromObjectiveC {
+        case .lineString: self = .lineString
+        case .number:     self = .number
+        case .point:      self = .point
+        case .polygon:    self = .polygon
+        case .string:     self = .string
+        }
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexDataType.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexDataType.swift
@@ -8,6 +8,13 @@
 
 import Foundation
 
+/// Defines the target data type of an index path specification in the Azure Cosmos DB service.
+///
+/// - ADIndexDataTypeLineString:   Represent a line string data type.
+/// - ADIndexDataTypeNumber:       Represent a numeric data type.
+/// - ADIndexDataTypePoint:        Represent a point data type.
+/// - ADIndexDataTypePolygon:      Represent a polygon data type.
+/// - ADIndexDataTypeString:       Represent a string data type.
 @objc(ADIndexDataType)
 public enum ADIndexDataType: Int {
     @objc(ADIndexDataTypeLineString)
@@ -25,6 +32,8 @@ public enum ADIndexDataType: Int {
     @objc(ADIndexDataTypeString)
     case string
 }
+
+// MARK: - Objective-C Bridging
 
 extension DocumentCollection.IndexingPolicy.IncludedPath.Index.DataType {
     var bridgedToObjectiveC: ADIndexDataType {

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexKind.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexKind.swift
@@ -8,6 +8,12 @@
 
 import Foundation
 
+/// These are the indexing types available for indexing a path in the Azure Cosmos DB service.
+///
+/// - ADIndexKindHash:     The index entries are hashed to serve point look up queries.
+/// - ADIndexKindRange:    The index entries are ordered. Range indexes are optimized for
+///                        inequality predicate queries with efficient range scans.
+/// - ADIndexKindSpatial:  The index entries are indexed to serve spatial queries.
 @objc(ADIndexKind)
 public enum ADIndexKind: Int {
     @objc(ADIndexKindHash)
@@ -19,6 +25,8 @@ public enum ADIndexKind: Int {
     @objc(ADIndexKindSpatial)
     case spatial
 }
+
+// MARK: - Objective-C Bridging
 
 extension DocumentCollection.IndexingPolicy.IncludedPath.Index.IndexKind {
     var bridgedToObjectiveC: ADIndexKind {

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexKind.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexKind.swift
@@ -1,0 +1,39 @@
+//
+//  ADIndexKind.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADIndexKind)
+public enum ADIndexKind: Int {
+    @objc(ADIndexKindHash)
+    case hash
+
+    @objc(ADIndexKindRange)
+    case range
+
+    @objc(ADIndexKindSpatial)
+    case spatial
+}
+
+extension DocumentCollection.IndexingPolicy.IncludedPath.Index.IndexKind {
+    var bridgedToObjectiveC: ADIndexKind {
+        switch self {
+        case .hash:    return .hash
+        case .range:   return .range
+        case .spatial: return .spatial
+        }
+    }
+
+    init(bridgedFromObjectiveC: ADIndexKind) {
+        switch bridgedFromObjectiveC {
+        case .hash:    self = .hash
+        case .range:   self = .range
+        case .spatial: self = .spatial
+        }
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexingMode.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexingMode.swift
@@ -1,0 +1,39 @@
+//
+//  ADIndexingMode.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADIndexingMode)
+public enum ADIndexingMode: Int {
+    @objc(ADIndexingModeConsistent)
+    case consistent
+
+    @objc(ADIndexingModeLazy)
+    case lazy
+
+    @objc(ADIndexingModeNone)
+    case none
+}
+
+extension DocumentCollection.IndexingPolicy.IndexingMode {
+    var bridgedToObjectiveC: ADIndexingMode {
+        switch self {
+        case .consistent: return .consistent
+        case .lazy:       return .lazy
+        case .none:       return .none
+        }
+    }
+
+    init(bridgedFromObjectiveC: ADIndexingMode) {
+        switch bridgedFromObjectiveC {
+        case .consistent: self = .consistent
+        case .lazy:       self = .lazy
+        case .none:       self = .none
+        }
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexingMode.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexingMode.swift
@@ -8,6 +8,11 @@
 
 import Foundation
 
+/// Specifies the supported indexing modes in the Azure Cosmos DB service.
+///
+/// - ADIndexingModeConsistent:   Index is updated synchronously with a create, update or delete operation.
+/// - ADIndexingModeLazy:         Index is updated asynchronously with respect to a create, update or delete operation.
+/// - ADIndexingModeNone:         No index is provided.
 @objc(ADIndexingMode)
 public enum ADIndexingMode: Int {
     @objc(ADIndexingModeConsistent)
@@ -19,6 +24,8 @@ public enum ADIndexingMode: Int {
     @objc(ADIndexingModeNone)
     case none
 }
+
+// MARK: - Objective-C Bridging
 
 extension DocumentCollection.IndexingPolicy.IndexingMode {
     var bridgedToObjectiveC: ADIndexingMode {

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexingPolicy.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexingPolicy.swift
@@ -76,7 +76,7 @@ extension DocumentCollection.IndexingPolicy: ObjectiveCBridgeable {
         )
     }
 
-    init?(bridgedFromObjectiveC: ADIndexingPolicy) {
+    init(bridgedFromObjectiveC: ADIndexingPolicy) {
         let automatic = bridgedFromObjectiveC.automatic
         let excludedPaths = bridgedFromObjectiveC.excludedPaths.compactMap { SwiftType.ExcludedPath(bridgedFromObjectiveC: $0) }
         let includedPaths = bridgedFromObjectiveC.includedPaths.compactMap { SwiftType.IncludedPath(bridgedFromObjectiveC: $0) }

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexingPolicy.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexingPolicy.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+/// Represents the indexing policy configuration for a collection in the Azure Cosmos DB service.
 @objc(ADIndexingPolicy)
 public class ADIndexingPolicy: NSObject, ADCodable {
     private enum CodingKeys: String, CodingKey {
@@ -19,15 +20,20 @@ public class ADIndexingPolicy: NSObject, ADCodable {
 
     private typealias SwiftType = DocumentCollection.IndexingPolicy
 
+    /// A value that indicates whether automatic indexing is enabled for a collection in
+    /// the Azure Cosmos DB service.
     @objc
     public let automatic: Bool
 
+    /// The collection containing `ADExcludedPath` objects in the Azure Cosmos DB service.
     @objc
     public let excludedPaths: [ADExcludedPath]
 
+    /// The collection containing `ADIncludedPath` objects in the Azure Cosmos DB service.
     @objc
     public let includedPaths: [ADIncludedPath]
 
+    /// The indexing mode in the Azure Cosmos DB service.
     @objc
     public let indexingMode: ADIndexingMode
 
@@ -38,6 +44,8 @@ public class ADIndexingPolicy: NSObject, ADCodable {
         self.includedPaths = includedPaths
         self.indexingMode = indexingMode
     }
+
+    // MARK: - ADCodable
 
     public required init?(from dictionary: NSDictionary) {
         self.automatic = dictionary[CodingKeys.automatic] as? Bool ?? false
@@ -62,6 +70,8 @@ public class ADIndexingPolicy: NSObject, ADCodable {
         return dictionary
     }
 }
+
+// MARK: - Objective-C Bridging
 
 extension DocumentCollection.IndexingPolicy: ObjectiveCBridgeable {
     typealias ObjectiveCType = ADIndexingPolicy

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexingPolicy.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADIndexingPolicy.swift
@@ -1,0 +1,87 @@
+//
+//  ADIndexingPolicy.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADIndexingPolicy)
+public class ADIndexingPolicy: NSObject, ADCodable {
+    private enum CodingKeys: String, CodingKey {
+        case automatic
+        case excludedPaths
+        case includedPaths
+        case indexingMode
+    }
+
+    private typealias SwiftType = DocumentCollection.IndexingPolicy
+
+    @objc
+    public let automatic: Bool
+
+    @objc
+    public let excludedPaths: [ADExcludedPath]
+
+    @objc
+    public let includedPaths: [ADIncludedPath]
+
+    @objc
+    public let indexingMode: ADIndexingMode
+
+    @objc
+    public init(automatic: Bool, excludedPaths: [ADExcludedPath], includedPaths: [ADIncludedPath], indexingMode: ADIndexingMode) {
+        self.automatic = automatic
+        self.excludedPaths = excludedPaths
+        self.includedPaths = includedPaths
+        self.indexingMode = indexingMode
+    }
+
+    public required init?(from dictionary: NSDictionary) {
+        self.automatic = dictionary[CodingKeys.automatic] as? Bool ?? false
+        self.excludedPaths = (dictionary[CodingKeys.excludedPaths] as? [NSDictionary])?.compactMap { ADExcludedPath(from: $0) } ?? []
+        self.includedPaths = (dictionary[CodingKeys.includedPaths] as? [NSDictionary])?.compactMap { ADIncludedPath(from: $0) } ?? []
+
+        if let indexingMode = dictionary[CodingKeys.indexingMode] as? String {
+            self.indexingMode = SwiftType.IndexingMode(rawValue: indexingMode)?.bridgedToObjectiveC ?? .none
+        } else {
+            self.indexingMode = .none
+        }
+    }
+
+    public func encode() -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+
+        dictionary[CodingKeys.automatic] = automatic
+        dictionary[CodingKeys.includedPaths] = includedPaths.map { $0.encode() }
+        dictionary[CodingKeys.excludedPaths] = excludedPaths.map { $0.encode() }
+        dictionary[CodingKeys.indexingMode] = SwiftType.IndexingMode(bridgedFromObjectiveC: indexingMode).rawValue
+
+        return dictionary
+    }
+}
+
+extension DocumentCollection.IndexingPolicy: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADIndexingPolicy
+    typealias SwiftType = DocumentCollection.IndexingPolicy
+
+    func bridgeToObjectiveC() -> ADIndexingPolicy {
+        return ADIndexingPolicy(
+            automatic: self.automatic ?? false,
+            excludedPaths: self.excludedPaths.map { $0.bridgeToObjectiveC() },
+            includedPaths: self.includedPaths.map { $0.bridgeToObjectiveC() },
+            indexingMode: (self.indexingMode?.bridgedToObjectiveC) ?? .none
+        )
+    }
+
+    init?(bridgedFromObjectiveC: ADIndexingPolicy) {
+        let automatic = bridgedFromObjectiveC.automatic
+        let excludedPaths = bridgedFromObjectiveC.excludedPaths.compactMap { SwiftType.ExcludedPath(bridgedFromObjectiveC: $0) }
+        let includedPaths = bridgedFromObjectiveC.includedPaths.compactMap { SwiftType.IncludedPath(bridgedFromObjectiveC: $0) }
+        let indexingMode = SwiftType.IndexingMode(bridgedFromObjectiveC: bridgedFromObjectiveC.indexingMode)
+
+        self.init(automatic: automatic, excludedPaths: excludedPaths, includedPaths: includedPaths, indexingMode: indexingMode)
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADPartitionKeyDefinition.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADPartitionKeyDefinition.swift
@@ -8,12 +8,14 @@
 
 import Foundation
 
+/// Specifies a partition key definition for a particular path in the Azure Cosmos DB service.
 @objc(ADPartitionKeyDefinition)
 public class ADPartitionKeyDefinition: NSObject, ADCodable {
     private enum CodingKeys: String, CodingKey {
         case paths
     }
 
+    /// The paths to be partitioned in the Azure Cosmos DB service.
     @objc
     public let paths: [String]
 
@@ -21,6 +23,8 @@ public class ADPartitionKeyDefinition: NSObject, ADCodable {
     public init(paths: [String]) {
         self.paths = paths
     }
+
+    // MARK: - ADCodable
 
     public required init?(from dictionary: NSDictionary) {
         guard let paths = dictionary[CodingKeys.paths] as? [String] else { return nil }
@@ -34,6 +38,8 @@ public class ADPartitionKeyDefinition: NSObject, ADCodable {
         return dictionary
     }
 }
+
+// MARK: - Objective-C Bridging
 
 extension DocumentCollection.PartitionKeyDefinition: ObjectiveCBridgeable {
     typealias ObjectiveCType = ADPartitionKeyDefinition

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADPartitionKeyDefinition.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADPartitionKeyDefinition.swift
@@ -1,0 +1,44 @@
+//
+//  ADPartitionKeyDefinition.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+@objc(ADPartitionKeyDefinition)
+public class ADPartitionKeyDefinition: NSObject, ADCodable {
+    private enum CodingKeys: String, CodingKey {
+        case paths
+    }
+
+    @objc
+    public let paths: [String]
+
+    @objc
+    public init(paths: [String]) {
+        self.paths = paths
+    }
+
+    public required init?(from dictionary: NSDictionary) {
+        guard let paths = dictionary[CodingKeys.paths] as? [String] else { return nil }
+        self.paths = paths
+    }
+
+    public func encode() -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+        dictionary[CodingKeys.paths] = paths
+
+        return dictionary
+    }
+}
+
+extension DocumentCollection.PartitionKeyDefinition: ObjectiveCBridgeable {
+    typealias ObjectiveCType = ADPartitionKeyDefinition
+
+    func bridgeToObjectiveC() -> ADPartitionKeyDefinition {
+        return ADPartitionKeyDefinition(paths: self.paths)
+    }
+}

--- a/AzureData/Source/Resources/Objective-C/DocumentCollection/ADPartitionKeyDefinition.swift
+++ b/AzureData/Source/Resources/Objective-C/DocumentCollection/ADPartitionKeyDefinition.swift
@@ -41,4 +41,8 @@ extension DocumentCollection.PartitionKeyDefinition: ObjectiveCBridgeable {
     func bridgeToObjectiveC() -> ADPartitionKeyDefinition {
         return ADPartitionKeyDefinition(paths: self.paths)
     }
+
+    init(bridgedFromObjectiveC: ObjectiveCType) {
+        self.init(paths: bridgedFromObjectiveC.paths)
+    }
 }

--- a/AzureData/Source/Resources/Offer.swift
+++ b/AzureData/Source/Resources/Offer.swift
@@ -56,6 +56,11 @@ public struct Offer : CodableResource {
         
         /// Represents customizable throughput chosen by user for his collection in the Azure Cosmos DB service.
         public private(set) var offerThroughput: Int = 1000
+
+        internal init(offerIsRUPerMinuteThroughputEnabled: Bool, offerThroughput: Int) {
+            self.offerIsRUPerMinuteThroughputEnabled = offerIsRUPerMinuteThroughputEnabled
+            self.offerThroughput = offerThroughput
+        }
     }
     
     public init (_ id: String) { self.id = id; resourceId = "" }
@@ -63,7 +68,6 @@ public struct Offer : CodableResource {
 
 
 extension Offer {
-    
     enum CodingKeys: String, CodingKey {
         case id
         case resourceId         = "_rid"
@@ -75,5 +79,19 @@ extension Offer {
         case resourceLink       = "resource"
         case offerResourceId
         case content
+    }
+
+    init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, offerType: String?, offerVersion: String?, resourceLink: String?, offerResourceId: String?, content: OfferContent?) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.timestamp = timestamp
+        self.altLink = altLink
+        self.offerType = offerType
+        self.offerVersion = offerVersion
+        self.resourceLink = resourceLink
+        self.offerResourceId = offerResourceId
+        self.content = content
     }
 }

--- a/AzureData/Source/Resources/Offer.swift
+++ b/AzureData/Source/Resources/Offer.swift
@@ -62,9 +62,9 @@ public struct Offer : CodableResource {
 }
 
 
-private extension Offer {
+extension Offer {
     
-    private enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case id
         case resourceId         = "_rid"
         case selfLink           = "_self"

--- a/AzureData/Source/Resources/Permission.swift
+++ b/AzureData/Source/Resources/Permission.swift
@@ -15,12 +15,12 @@ public struct Permission : CodableResource {
     public static var type = "permissions"
     public static var list = "Permissions"
 
-    public internal(set) var id:         String
-    public internal(set) var resourceId: String
-    public internal(set) var selfLink:   String?
-    public internal(set) var etag:       String?
-    public internal(set) var timestamp:  Date?
-    public internal(set) var altLink:    String? = nil
+    public private(set) var id:         String
+    public private(set) var resourceId: String
+    public private(set) var selfLink:   String?
+    public private(set) var etag:       String?
+    public private(set) var timestamp:  Date?
+    public private(set) var altLink:    String? = nil
     
     public mutating func setAltLink(to link: String) {
         self.altLink = link
@@ -30,10 +30,10 @@ public struct Permission : CodableResource {
     }
 
     /// Gets or sets the permission mode in the Azure Cosmos DB service.
-    public internal(set) var permissionMode: PermissionMode
+    public private(set) var permissionMode: PermissionMode
     
     /// Gets or sets the self-link of resource to which the permission applies in the Azure Cosmos DB service.
-    public internal(set) var resourceLink: String?
+    public private(set) var resourceLink: String?
     
 //    /// Gets or sets optional partition key value for the permission in the Azure Cosmos DB service.
 //    /// A permission applies to resources when two conditions are met:
@@ -45,7 +45,7 @@ public struct Permission : CodableResource {
 //    public private(set) var resourcePartitionKey:   String?
     
     /// Gets the access token granting the defined permission from the Azure Cosmos DB service.
-    public internal(set) var token: String?
+    public private(set) var token: String?
     
     init(_ id: String, mode: PermissionMode, forResource resource: String) {
         self.id = id
@@ -57,7 +57,6 @@ public struct Permission : CodableResource {
 
 
 extension Permission {
-    
     enum CodingKeys: String, CodingKey {
         case id
         case resourceId     = "_rid"
@@ -67,5 +66,17 @@ extension Permission {
         case permissionMode
         case resourceLink   = "resource"
         case token          = "_token"
+    }
+
+    init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, permissionMode: PermissionMode, resourceLink: String?, token: String?) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.timestamp = timestamp
+        self.altLink = altLink
+        self.permissionMode = permissionMode
+        self.resourceLink = resourceLink
+        self.token = token
     }
 }

--- a/AzureData/Source/Resources/Permission.swift
+++ b/AzureData/Source/Resources/Permission.swift
@@ -15,12 +15,12 @@ public struct Permission : CodableResource {
     public static var type = "permissions"
     public static var list = "Permissions"
 
-    public private(set) var id:         String
-    public private(set) var resourceId: String
-    public private(set) var selfLink:   String?
-    public private(set) var etag:       String?
-    public private(set) var timestamp:  Date?
-    public private(set) var altLink:    String? = nil
+    public internal(set) var id:         String
+    public internal(set) var resourceId: String
+    public internal(set) var selfLink:   String?
+    public internal(set) var etag:       String?
+    public internal(set) var timestamp:  Date?
+    public internal(set) var altLink:    String? = nil
     
     public mutating func setAltLink(to link: String) {
         self.altLink = link
@@ -30,10 +30,10 @@ public struct Permission : CodableResource {
     }
 
     /// Gets or sets the permission mode in the Azure Cosmos DB service.
-    public private(set) var permissionMode: PermissionMode
+    public internal(set) var permissionMode: PermissionMode
     
     /// Gets or sets the self-link of resource to which the permission applies in the Azure Cosmos DB service.
-    public private(set) var resourceLink: String?
+    public internal(set) var resourceLink: String?
     
 //    /// Gets or sets optional partition key value for the permission in the Azure Cosmos DB service.
 //    /// A permission applies to resources when two conditions are met:
@@ -45,7 +45,7 @@ public struct Permission : CodableResource {
 //    public private(set) var resourcePartitionKey:   String?
     
     /// Gets the access token granting the defined permission from the Azure Cosmos DB service.
-    public private(set) var token: String?
+    public internal(set) var token: String?
     
     init(_ id: String, mode: PermissionMode, forResource resource: String) {
         self.id = id
@@ -56,9 +56,9 @@ public struct Permission : CodableResource {
 }
 
 
-private extension Permission {
+extension Permission {
     
-    private enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case id
         case resourceId     = "_rid"
         case selfLink       = "_self"

--- a/AzureData/Source/Resources/ResourceSystemProperties.swift
+++ b/AzureData/Source/Resources/ResourceSystemProperties.swift
@@ -23,12 +23,12 @@ struct ResourceSystemProperties: CodableResource {
     static var type = ""
     static var list = ""
 
-    var id:                 String
+    var id:         String
     var resourceId: String
     var selfLink:   String?
-    var etag:               String?
-    var timestamp:          Date?
-    var altLink:            String? = nil
+    var etag:       String?
+    var timestamp:  Date?
+    var altLink:    String? = nil
 
     mutating func setEtag(to tag: String) { etag = tag }
     mutating func setAltLink(to link: String) { altLink = link }
@@ -56,11 +56,15 @@ extension Data {
         return ResourceSystemProperties(for: self)?.id
     }
 
+    var resourceId: String? {
+        return ResourceSystemProperties(for: self)?.resourceId
+    }
+
     var selfLink: String? {
         return ResourceSystemProperties(for: self)?.selfLink
     }
 
-    var resourceId: String? {
-        return ResourceSystemProperties(for: self)?.resourceId
+    var etag: String? {
+        return ResourceSystemProperties(for: self)?.etag
     }
 }

--- a/AzureData/Source/Resources/StoredProcedure.swift
+++ b/AzureData/Source/Resources/StoredProcedure.swift
@@ -19,12 +19,12 @@ public struct StoredProcedure : CodableResource, SupportsPermissionToken {
     public static var type = "sprocs"
     public static var list = "StoredProcedures"
 
-    public internal(set) var id:         String
-    public internal(set) var resourceId: String
-    public internal(set) var selfLink:   String?
-    public internal(set) var etag:       String?
-    public internal(set) var timestamp:  Date?
-    public internal(set) var altLink:    String? = nil
+    public private(set) var id:         String
+    public private(set) var resourceId: String
+    public private(set) var selfLink:   String?
+    public private(set) var etag:       String?
+    public private(set) var timestamp:  Date?
+    public private(set) var altLink:    String? = nil
     
     public mutating func setAltLink(to link: String) {
         self.altLink = link
@@ -41,7 +41,7 @@ public struct StoredProcedure : CodableResource, SupportsPermissionToken {
     ///
     /// - Example:
     ///   `"function () { getContext().getResponse().setBody('Hello World!'); }`
-    public internal(set) var body:       String?
+    public private(set) var body:       String?
     
     public init (_ id: String, body: String) {
         self.id = id
@@ -52,7 +52,6 @@ public struct StoredProcedure : CodableResource, SupportsPermissionToken {
 
 
 extension StoredProcedure {
-    
     enum CodingKeys: String, CodingKey {
         case id
         case resourceId         = "_rid"
@@ -60,5 +59,15 @@ extension StoredProcedure {
         case etag               = "_etag"
         case timestamp          = "_ts"
         case body
+    }
+
+    init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, body: String?) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.timestamp = timestamp
+        self.altLink = altLink
+        self.body = body
     }
 }

--- a/AzureData/Source/Resources/StoredProcedure.swift
+++ b/AzureData/Source/Resources/StoredProcedure.swift
@@ -19,12 +19,12 @@ public struct StoredProcedure : CodableResource, SupportsPermissionToken {
     public static var type = "sprocs"
     public static var list = "StoredProcedures"
 
-    public private(set) var id:         String
-    public private(set) var resourceId: String
-    public private(set) var selfLink:   String?
-    public private(set) var etag:       String?
-    public private(set) var timestamp:  Date?
-    public private(set) var altLink:    String? = nil
+    public internal(set) var id:         String
+    public internal(set) var resourceId: String
+    public internal(set) var selfLink:   String?
+    public internal(set) var etag:       String?
+    public internal(set) var timestamp:  Date?
+    public internal(set) var altLink:    String? = nil
     
     public mutating func setAltLink(to link: String) {
         self.altLink = link
@@ -41,7 +41,7 @@ public struct StoredProcedure : CodableResource, SupportsPermissionToken {
     ///
     /// - Example:
     ///   `"function () { getContext().getResponse().setBody('Hello World!'); }`
-    public private(set) var body:       String?
+    public internal(set) var body:       String?
     
     public init (_ id: String, body: String) {
         self.id = id
@@ -51,9 +51,9 @@ public struct StoredProcedure : CodableResource, SupportsPermissionToken {
 }
 
 
-private extension StoredProcedure {
+extension StoredProcedure {
     
-    private enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case id
         case resourceId         = "_rid"
         case selfLink           = "_self"

--- a/AzureData/Source/Resources/Trigger.swift
+++ b/AzureData/Source/Resources/Trigger.swift
@@ -64,8 +64,7 @@ public struct Trigger : CodableResource, SupportsPermissionToken {
         case pre  = "Pre"
         case post = "Post"
     }
-    
-    
+
     init(_ id: String, body: String, operation: TriggerOperation, type: TriggerType) {
         self.id = id
         self.resourceId = ""
@@ -77,7 +76,6 @@ public struct Trigger : CodableResource, SupportsPermissionToken {
 
 
 extension Trigger {
-    
     enum CodingKeys: String, CodingKey {
         case id
         case resourceId         = "_rid"
@@ -87,5 +85,16 @@ extension Trigger {
         case body
         case triggerOperation
         case triggerType
+    }
+
+    init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, body: String?, triggerOperation: TriggerOperation?, triggerType: TriggerType?) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.timestamp = timestamp
+        self.altLink = altLink
+        self.triggerOperation = triggerOperation
+        self.triggerType = triggerType
     }
 }

--- a/AzureData/Source/Resources/Trigger.swift
+++ b/AzureData/Source/Resources/Trigger.swift
@@ -76,9 +76,9 @@ public struct Trigger : CodableResource, SupportsPermissionToken {
 }
 
 
-private extension Trigger {
+extension Trigger {
     
-    private enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case id
         case resourceId         = "_rid"
         case selfLink           = "_self"

--- a/AzureData/Source/Resources/User.swift
+++ b/AzureData/Source/Resources/User.swift
@@ -14,12 +14,12 @@ public struct User : CodableResource {
     public static var type = "users"
     public static var list = "Users"
 
-    public internal(set) var id:         String
-    public internal(set) var resourceId: String
-    public internal(set) var selfLink:   String?
-    public internal(set) var etag:       String?
-    public internal(set) var timestamp:  Date?
-    public internal(set) var altLink:    String? = nil
+    public private(set) var id:         String
+    public private(set) var resourceId: String
+    public private(set) var selfLink:   String?
+    public private(set) var etag:       String?
+    public private(set) var timestamp:  Date?
+    public private(set) var altLink:    String? = nil
     
     public mutating func setAltLink(to link: String) {
         self.altLink = link
@@ -29,14 +29,13 @@ public struct User : CodableResource {
     }
 
     /// Gets the self-link of the permissions associated with the user for the Azure Cosmos DB service.
-    public internal(set) var permissionsLink:String?
+    public private(set) var permissionsLink:String?
     
     public init (_ id: String) { self.id = id; resourceId = "" }
 }
 
 
 extension User {
-    
     enum CodingKeys: String, CodingKey {
         case id
         case resourceId         = "_rid"
@@ -44,5 +43,15 @@ extension User {
         case etag               = "_etag"
         case timestamp          = "_ts"
         case permissionsLink    = "_permissions"
+    }
+
+    init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, permissionsLink: String?) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.timestamp = timestamp
+        self.altLink = altLink
+        self.permissionsLink = permissionsLink
     }
 }

--- a/AzureData/Source/Resources/User.swift
+++ b/AzureData/Source/Resources/User.swift
@@ -14,12 +14,12 @@ public struct User : CodableResource {
     public static var type = "users"
     public static var list = "Users"
 
-    public private(set) var id:         String
-    public private(set) var resourceId: String
-    public private(set) var selfLink:   String?
-    public private(set) var etag:       String?
-    public private(set) var timestamp:  Date?
-    public private(set) var altLink:    String? = nil
+    public internal(set) var id:         String
+    public internal(set) var resourceId: String
+    public internal(set) var selfLink:   String?
+    public internal(set) var etag:       String?
+    public internal(set) var timestamp:  Date?
+    public internal(set) var altLink:    String? = nil
     
     public mutating func setAltLink(to link: String) {
         self.altLink = link
@@ -29,15 +29,15 @@ public struct User : CodableResource {
     }
 
     /// Gets the self-link of the permissions associated with the user for the Azure Cosmos DB service.
-    public private(set) var permissionsLink:String?
+    public internal(set) var permissionsLink:String?
     
     public init (_ id: String) { self.id = id; resourceId = "" }
 }
 
 
-private extension User {
+extension User {
     
-    private enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case id
         case resourceId         = "_rid"
         case selfLink           = "_self"

--- a/AzureData/Source/Resources/UserDefinedFunction.swift
+++ b/AzureData/Source/Resources/UserDefinedFunction.swift
@@ -20,12 +20,12 @@ public struct UserDefinedFunction : CodableResource, SupportsPermissionToken {
     public static var type = "udfs"
     public static var list = "UserDefinedFunctions"
 
-    public internal(set) var id:         String
-    public internal(set) var resourceId: String
-    public internal(set) var selfLink:   String?
-    public internal(set) var etag:       String?
-    public internal(set) var timestamp:  Date?
-    public internal(set) var altLink:    String? = nil
+    public private(set) var id:         String
+    public private(set) var resourceId: String
+    public private(set) var selfLink:   String?
+    public private(set) var etag:       String?
+    public private(set) var timestamp:  Date?
+    public private(set) var altLink:    String? = nil
     
     public mutating func setAltLink(to link: String) {
         self.altLink = link
@@ -41,7 +41,7 @@ public struct UserDefinedFunction : CodableResource, SupportsPermissionToken {
     ///
     /// - Example:
     ///   `"function (input) { return input.toLowerCase(); }"`
-    public internal(set) var body: String?
+    public private(set) var body: String?
     
     public init (_ id: String, body: String) {
         self.id = id
@@ -52,7 +52,6 @@ public struct UserDefinedFunction : CodableResource, SupportsPermissionToken {
 
 
 extension UserDefinedFunction {
-    
     enum CodingKeys: String, CodingKey {
         case id
         case resourceId = "_rid"
@@ -60,5 +59,15 @@ extension UserDefinedFunction {
         case etag       = "_etag"
         case timestamp  = "_ts"
         case body
+    }
+
+    init(id: String, resourceId: String, selfLink: String?, etag: String?, timestamp: Date?, altLink: String?, body: String?) {
+        self.id = id
+        self.resourceId = resourceId
+        self.selfLink = selfLink
+        self.etag = etag
+        self.timestamp = timestamp
+        self.altLink = altLink
+        self.body = body
     }
 }

--- a/AzureData/Source/Resources/UserDefinedFunction.swift
+++ b/AzureData/Source/Resources/UserDefinedFunction.swift
@@ -20,12 +20,12 @@ public struct UserDefinedFunction : CodableResource, SupportsPermissionToken {
     public static var type = "udfs"
     public static var list = "UserDefinedFunctions"
 
-    public private(set) var id:         String
-    public private(set) var resourceId: String
-    public private(set) var selfLink:   String?
-    public private(set) var etag:       String?
-    public private(set) var timestamp:  Date?
-    public private(set) var altLink:    String? = nil
+    public internal(set) var id:         String
+    public internal(set) var resourceId: String
+    public internal(set) var selfLink:   String?
+    public internal(set) var etag:       String?
+    public internal(set) var timestamp:  Date?
+    public internal(set) var altLink:    String? = nil
     
     public mutating func setAltLink(to link: String) {
         self.altLink = link
@@ -41,7 +41,7 @@ public struct UserDefinedFunction : CodableResource, SupportsPermissionToken {
     ///
     /// - Example:
     ///   `"function (input) { return input.toLowerCase(); }"`
-    public private(set) var body: String?
+    public internal(set) var body: String?
     
     public init (_ id: String, body: String) {
         self.id = id
@@ -51,9 +51,9 @@ public struct UserDefinedFunction : CodableResource, SupportsPermissionToken {
 }
 
 
-private extension UserDefinedFunction {
+extension UserDefinedFunction {
     
-    private enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case id
         case resourceId = "_rid"
         case selfLink   = "_self"

--- a/AzureData/Source/Response.swift
+++ b/AzureData/Source/Response.swift
@@ -84,6 +84,27 @@ extension Response where T:CodableResource {
     }
 }
 
+extension Response {
+    public func map<U>(_ transform: (T) throws -> U) -> Response<U> {
+        return Response<U>(
+            request: request,
+            data: data,
+            response: response,
+            result: result.map(transform),
+            fromCache: fromCache
+        )
+    }
+}
+
+extension Result {
+    public func map<U>(_ transform: (T) throws -> U) -> Result<U> {
+        do {
+            return try isSuccess ? Result<U>.success(transform(resource!)) : Result<U>.failure(error!)
+        } catch {
+            return Result<U>.failure(error)
+        }
+    }
+}
 
 // MARK: - CustomStringConvertible
 


### PR DESCRIPTION
Fixes #74.

Changes Proposed in this pull request:
- Ensure that `AzureData` has a clean and expressive Objective-C API.

### Usage

```objc

// Configuration
[ADAzureData
    configureForAccountNamed:@"accountName"
    withMasterKey:@"accountMasterKey"
    andPermissionMode:ADPermissionModeAll
];

// Create a database
[ADAzureData createDatabaseWithId:@"databaseId" completion:^(ADResponse* response) {
    if ([[response result] isSuccess]) {
        ADDatabase* database = [response resource];
        // [database id] == @"databaseId"
    }
    // ...
}];

// Get all databases
[ADAzureData getDatabasesWithCompletion:^(ADResponse* response) {
   if ([[response result] isSuccess]) {
        ADResources* resources = [response resource];
        // databases = [resources items]
   }
}];

// Create a document

@interface Person: ADDocument
@property NSString* name;
@end

@implementation Person
- (nullable instancetype)initFrom:(NSDictionary *)dictionary {
    self = [super initFrom:dictionary];
    if (self) {  _name = [dictionary valueForKey:@"name"];  }
    return self;
}

- (NSDictionary* _Nonnull)encode {
    NSMutableDictionary* dictionary = (NSMutableDictionary*)[super encode];
    [dictionary setValue:_name forKey:@"name"];
    return dictionary;
}
@end

Person* me = [[Person alloc] initWithId:@"1"];
person.name = @"Faiçal";

[ADAzureData createDocument:me inCollectionWithId:@"collectionId" inDatabaseWithId:@"databaseId" completion:^(ADResponse* r) {
   if ([[response result] isSuccess]) {
        Person* resource = [response resource];
        // [resource name] == @"Faiçal"
   }
}];
```
