### PR TITLE
Fix project reference in workspace

### DIFF
--- a/Azure.xcworkspace/contents.xcworkspacedata
+++ b/Azure.xcworkspace/contents.xcworkspacedata
@@ -23,7 +23,7 @@
       location = "container:"
       name = "Azure.iOS ObjC">
       <FileRef
-         location = "group:/Users/colbylwilliams/GitHub/Azure.iOS/AzureData ObjC/AzureData ObjC.xcodeproj">
+         location = "group:AzureData ObjC/AzureData ObjC.xcodeproj">
       </FileRef>
    </Group>
    <Group


### PR DESCRIPTION
Hi,

I just checked out the project and found that the `.xcworkspace` contained an invalid  reference to the AzureData ObJC project file so I fixed it.