### PR TITLE
Geometry Query API Updates

### DIFF
--- a/AzureData/Source/Geometry/Query+Geometry.swift
+++ b/AzureData/Source/Geometry/Query+Geometry.swift
@@ -10,7 +10,10 @@ import Foundation
 import CoreLocation
 
 extension Query {
-    public func `where`(_ property: String, to point: Point, isLessThan distance: CLLocationDistance) -> Query {
+
+    // MARK: - Where
+
+    public func `where`(distanceFrom property: String, to point: Point, isLessThan distance: CLLocationDistance) -> Query {
         assert(!whereCalled, "you can only call `where` once, to add more constraints use `and`")
 
         whereFragment = "ST_DISTANCE(\(type!).\(property), {'type': 'Point', 'coordinates':[\(point.coordinate.longitude), \(point.coordinate.latitude)]}) < \(distance)"
@@ -20,7 +23,7 @@ extension Query {
         return self
     }
 
-    public func `where`(_ property: String, to point: Point, isLessThanOrEqualTo distance: CLLocationDistance) -> Query {
+    public func `where`(distanceFrom property: String, to point: Point, isLessThanOrEqualTo distance: CLLocationDistance) -> Query {
         assert(!whereCalled, "you can only call `where` once, to add more constraints use `and`")
 
         whereFragment = "ST_DISTANCE(\(type!).\(property), {'type': 'Point', 'coordinates':[\(point.coordinate.longitude), \(point.coordinate.latitude)]}) <= \(distance)"
@@ -30,7 +33,7 @@ extension Query {
         return self
     }
 
-    public func `where`(_ property: String, to point: Point, is distance: CLLocationDistance) -> Query {
+    public func `where`(distanceFrom property: String, to point: Point, is distance: CLLocationDistance) -> Query {
         assert(!whereCalled, "you can only call `where` once, to add more constraints use `and`")
 
         whereFragment = "ST_DISTANCE(\(type!).\(property), {'type': 'Point', 'coordinates':[\(point.coordinate.longitude), \(point.coordinate.latitude)]}) = \(distance)"
@@ -40,7 +43,7 @@ extension Query {
         return self
     }
 
-    public func `where`(_ property: String, to point: Point, isGreaterThan distance: CLLocationDistance) -> Query {
+    public func `where`(distanceFrom property: String, to point: Point, isGreaterThan distance: CLLocationDistance) -> Query {
         assert(!whereCalled, "you can only call `where` once, to add more constraints use `and`")
 
         whereFragment = "ST_DISTANCE(\(type!).\(property), {'type': 'Point', 'coordinates':[\(point.coordinate.longitude), \(point.coordinate.latitude)]}) > \(distance)"
@@ -50,12 +53,59 @@ extension Query {
         return self
     }
 
-    public func `where`(_ property: String, to point: Point, isGreaterThanOrEqualTo distance: CLLocationDistance) -> Query {
+    public func `where`(distanceFrom property: String, to point: Point, isGreaterThanOrEqualTo distance: CLLocationDistance) -> Query {
         assert(!whereCalled, "you can only call `where` once, to add more constraints use `and`")
 
         whereFragment = "ST_DISTANCE(\(type!).\(property), {'type': 'Point', 'coordinates':[\(point.coordinate.longitude), \(point.coordinate.latitude)]}) >= \(distance)"
         whereCalled = true
         spatialWhereCalled = true
+
+        return self
+    }
+
+    // MARK: - And
+
+    public func and(distanceFrom property: String, to point: Point, isLessThan distance: CLLocationDistance) -> Query {
+        assert(whereCalled, "must call where before calling and")
+
+        spatialAndFragments.append("ST_DISTANCE(\(type!).\(property), {'type': 'Point', 'coordinates':[\(point.coordinate.longitude), \(point.coordinate.latitude)]}) < \(distance)")
+        spatialAndCalled = true
+
+        return self
+    }
+
+    public func and(distanceFrom property: String, to point: Point, isLessThanOrEqualTo distance: CLLocationDistance) -> Query {
+        assert(whereCalled, "must call where before calling and")
+
+        spatialAndFragments.append("ST_DISTANCE(\(type!).\(property), {'type': 'Point', 'coordinates':[\(point.coordinate.longitude), \(point.coordinate.latitude)]}) <= \(distance)")
+        spatialAndCalled = true
+
+        return self
+    }
+
+    public func and(distanceFrom property: String, to point: Point, is distance: CLLocationDistance) -> Query {
+        assert(whereCalled, "must call where before calling and")
+
+        spatialAndFragments.append("ST_DISTANCE(\(type!).\(property), {'type': 'Point', 'coordinates':[\(point.coordinate.longitude), \(point.coordinate.latitude)]}) = \(distance)")
+        spatialAndCalled = true
+
+        return self
+    }
+
+    public func and(distanceFrom property: String, to point: Point, isGreaterThan distance: CLLocationDistance) -> Query {
+        assert(whereCalled, "must call where before calling and")
+
+        spatialAndFragments.append("ST_DISTANCE(\(type!).\(property), {'type': 'Point', 'coordinates':[\(point.coordinate.longitude), \(point.coordinate.latitude)]}) > \(distance)")
+        spatialAndCalled = true
+
+        return self
+    }
+
+    public func and(distanceFrom property: String, to point: Point, isGreaterThanOrEqualTo distance: CLLocationDistance) -> Query {
+        assert(whereCalled, "must call where before calling and")
+
+        spatialAndFragments.append("ST_DISTANCE(\(type!).\(property), {'type': 'Point', 'coordinates':[\(point.coordinate.longitude), \(point.coordinate.latitude)]}) >= \(distance)")
+        spatialAndCalled = true
 
         return self
     }

--- a/AzureData/Source/Query.swift
+++ b/AzureData/Source/Query.swift
@@ -15,12 +15,14 @@ public class Query : Encodable {
     internal var whereCalled        = false
     internal var spatialWhereCalled = false
     internal var andCalled          = false
+    internal var spatialAndCalled   = false
     internal var orderByCalled      = false
 
-    internal var selectProperties:   [String] = []
+    internal var selectProperties:    [String] = []
     internal var fromFragment:        String?
     internal var whereFragment:       String?
-    internal var andFragments:       [String] = []
+    internal var andFragments:        [String] = []
+    internal var spatialAndFragments: [String] = []
     internal var orderByFragment:     String?
     
     internal var type:       String?
@@ -82,6 +84,11 @@ public class Query : Encodable {
                 if andCalled && !andFragments.isEmpty {
                     query += " AND \(type!)."
                     query += andFragments.joined(separator: " AND \(type!).")
+                }
+
+                if spatialAndCalled && !spatialAndFragments.isEmpty {
+                    query += " AND "
+                    query += spatialAndFragments.joined(separator: " AND ")
                 }
             }
             

--- a/AzureData/Source/ResourceCache.swift
+++ b/AzureData/Source/ResourceCache.swift
@@ -105,6 +105,8 @@ public class ResourceCache {
     static func cache<T: CodableResource>(_ resources: Resources<T>, for query: Query, usingContentPath contentPath: String) {
         guard resources.count > 0 else { return }
 
+        ResourceOracle.storeLinks(forResources: resources)
+
         dispatchQueue.async {
             let metadata = ResourcesMetadata(resourceId: resources.resourceId, contentPath: contentPath)
 

--- a/AzureData/Source/Resources/DocumentContainer.swift
+++ b/AzureData/Source/Resources/DocumentContainer.swift
@@ -24,11 +24,11 @@ final class DocumentContainer<DocumentType: Document>: CodableResource, Supports
     var document: DocumentType
 
     func setAltLink(to link: String) {
-        metadata.altLink = altLink
+        metadata.altLink = link
     }
 
     func setEtag(to tag: String) {
-        metadata.etag = etag
+        metadata.etag = tag
     }
 
     internal init(_ document: DocumentType) {

--- a/AzureData/Tests/PointTests.swift
+++ b/AzureData/Tests/PointTests.swift
@@ -41,7 +41,7 @@ class PointTests: XCTestCase {
 
     func testLessThanDistanceQuery() {
         let query = Query().from("Document")
-            .where("location", to: [42.12, 34.4], isLessThan: 3000)
+            .where(distanceFrom: "location", to: [42.12, 34.4], isLessThan: 3000)
             .query
 
         XCTAssertEqual(query, "SELECT * FROM Document WHERE ST_DISTANCE(Document.location, {\'type\': \'Point\', \'coordinates\':[42.12, 34.4]}) < 3000.0")
@@ -49,7 +49,7 @@ class PointTests: XCTestCase {
 
     func testLessThanOrEqualToDistanceQuery() {
         let query = Query().from("Document")
-            .where("location", to: [42.12, 34.4], isLessThanOrEqualTo: 3000)
+            .where(distanceFrom: "location", to: [42.12, 34.4], isLessThanOrEqualTo: 3000)
             .query
 
         XCTAssertEqual(query, "SELECT * FROM Document WHERE ST_DISTANCE(Document.location, {\'type\': \'Point\', \'coordinates\':[42.12, 34.4]}) <= 3000.0")
@@ -57,7 +57,7 @@ class PointTests: XCTestCase {
 
     func testEqualToDistanceQuery() {
         let query = Query().from("Document")
-            .where("location", to: [42.12, 34.4], is: 3000)
+            .where(distanceFrom: "location", to: [42.12, 34.4], is: 3000)
             .query
 
         XCTAssertEqual(query, "SELECT * FROM Document WHERE ST_DISTANCE(Document.location, {\'type\': \'Point\', \'coordinates\':[42.12, 34.4]}) = 3000.0")
@@ -65,7 +65,7 @@ class PointTests: XCTestCase {
 
     func testGreaterThanDistanceQuery() {
         let query = Query().from("Document")
-            .where("location", to: [42.12, 34.4], isGreaterThan: 3000)
+            .where(distanceFrom: "location", to: [42.12, 34.4], isGreaterThan: 3000)
             .query
 
         XCTAssertEqual(query, "SELECT * FROM Document WHERE ST_DISTANCE(Document.location, {\'type\': \'Point\', \'coordinates\':[42.12, 34.4]}) > 3000.0")
@@ -73,9 +73,54 @@ class PointTests: XCTestCase {
 
     func testGreatherThanOrEqualToDistanceQuery() {
         let query = Query().from("Document")
-            .where("location", to: [42.12, 34.4], isGreaterThanOrEqualTo: 3000)
+            .where(distanceFrom: "location", to: [42.12, 34.4], isGreaterThanOrEqualTo: 3000)
             .query
 
         XCTAssertEqual(query, "SELECT * FROM Document WHERE ST_DISTANCE(Document.location, {\'type\': \'Point\', \'coordinates\':[42.12, 34.4]}) >= 3000.0")
+    }
+
+    func testAndDistanceLessThanQuery() {
+        let query = Query().from("Document")
+            .where("age", isLessThan: 42)
+            .and(distanceFrom: "location", to: [42.12, 34.4], isLessThan: 3000)
+            .query
+
+        XCTAssertEqual(query, "SELECT * FROM Document WHERE Document.age < 42 AND ST_DISTANCE(Document.location, {\'type\': \'Point\', \'coordinates\':[42.12, 34.4]}) < 3000.0")
+    }
+
+    func testAndDistanceLessThanOrEqualToQuery() {
+        let query = Query().from("Document")
+            .where("age", isLessThan: 42)
+            .and(distanceFrom: "location", to: [42.12, 34.4], isLessThanOrEqualTo: 3000)
+            .query
+
+        XCTAssertEqual(query, "SELECT * FROM Document WHERE Document.age < 42 AND ST_DISTANCE(Document.location, {\'type\': \'Point\', \'coordinates\':[42.12, 34.4]}) <= 3000.0")
+    }
+
+    func testAndDistanceisEqualToQuery() {
+        let query = Query().from("Document")
+            .where("age", isLessThan: 42)
+            .and(distanceFrom: "location", to: [42.12, 34.4], is: 3000)
+            .query
+
+        XCTAssertEqual(query, "SELECT * FROM Document WHERE Document.age < 42 AND ST_DISTANCE(Document.location, {\'type\': \'Point\', \'coordinates\':[42.12, 34.4]}) = 3000.0")
+    }
+
+    func testAndDistanceIsGreaterThanQuery() {
+        let query = Query().from("Document")
+            .where("age", isLessThan: 42)
+            .and(distanceFrom: "location", to: [42.12, 34.4], isGreaterThan: 3000)
+            .query
+
+        XCTAssertEqual(query, "SELECT * FROM Document WHERE Document.age < 42 AND ST_DISTANCE(Document.location, {\'type\': \'Point\', \'coordinates\':[42.12, 34.4]}) > 3000.0")
+    }
+
+    func testAndDistanceIsGreaterThanOrEqualToQuery() {
+        let query = Query().from("Document")
+            .where("age", isLessThan: 42)
+            .and(distanceFrom: "location", to: [42.12, 34.4], isGreaterThanOrEqualTo: 3000)
+            .query
+
+        XCTAssertEqual(query, "SELECT * FROM Document WHERE Document.age < 42 AND ST_DISTANCE(Document.location, {\'type\': \'Point\', \'coordinates\':[42.12, 34.4]}) >= 3000.0")
     }
 }


### PR DESCRIPTION
Changes Proposed in this pull request:
- Make there `where` operator for geometric queries more explicit (e.g. `where(distanceFrom:to:is:)`)
- Add the `and` operator support to geometric queries
- Fix a bug where `altLink` and `etag` were assigned to themselves in `DocumentContainer`
- Store the links (self and alt) in the resource oracle for resources returned as a result of a query