### PR TITLE
Add support for partial document querying

### DIFF
--- a/AzureAuth/AzureAuth.xcodeproj/project.pbxproj
+++ b/AzureAuth/AzureAuth.xcodeproj/project.pbxproj
@@ -429,6 +429,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 93F80562202BB24600D0B4F4;
 			productRefGroup = 93F8056D202BB24600D0B4F4 /* Products */;

--- a/AzureCore/AzureCore.xcodeproj/project.pbxproj
+++ b/AzureCore/AzureCore.xcodeproj/project.pbxproj
@@ -511,6 +511,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 93F8053E202BB20300D0B4F4;
 			productRefGroup = 93F80549202BB20300D0B4F4 /* Products */;

--- a/AzureCore/Source/DateFormat.swift
+++ b/AzureCore/Source/DateFormat.swift
@@ -63,7 +63,7 @@ public struct DateFormat {
     }
 }
 
-public extension DateFormatter {
+extension DateFormatter {
     
     public func roundTripIso8601StringWithMicroseconds(from date: Date) -> String {
         

--- a/AzureCore/Source/HttpHeader.swift
+++ b/AzureCore/Source/HttpHeader.swift
@@ -55,7 +55,7 @@ public enum HttpHeader : String {
 }
 
 
-public extension Dictionary where Key == HttpHeader, Value == String  {
+extension Dictionary where Key == HttpHeader, Value == String  {
     public var strings: [String:String] {
         return Dictionary<String, String>.init(uniqueKeysWithValues: self.map{ (k, v) in
             (k.rawValue, v)
@@ -64,7 +64,7 @@ public extension Dictionary where Key == HttpHeader, Value == String  {
 }
 
 
-public extension Dictionary where Key == String, Value == String {
+extension Dictionary where Key == String, Value == String {
     public subscript (index: HttpHeader) -> String? {
         get {
             return self[index.rawValue]
@@ -75,7 +75,7 @@ public extension Dictionary where Key == String, Value == String {
     }
 }
 
-public extension Dictionary where Key == String, Value == Any {
+extension Dictionary where Key == String, Value == Any {
     public subscript (index: HttpHeader) -> Any? {
         get {
             return self[index.rawValue]
@@ -86,13 +86,13 @@ public extension Dictionary where Key == String, Value == Any {
     }
 }
 
-public extension URLRequest {
+extension URLRequest {
     public mutating func addValue(_ value: String, forHTTPHeaderField: HttpHeader) {
         self.addValue(value, forHTTPHeaderField: forHTTPHeaderField.rawValue)
     }
 }
 
-public extension Bundle {
+extension Bundle {
     
     /// Creates default values for the "Accept-Encoding", "Accept-Language", and "User-Agent" headers.
     public var defaultHttpHeaders: HttpHeaders {

--- a/AzureCore/Source/HttpMethod.swift
+++ b/AzureCore/Source/HttpMethod.swift
@@ -38,7 +38,7 @@ public enum HttpMethod : String {
 }
 
 
-public extension URLRequest {
+extension URLRequest {
     
     public var method: HttpMethod? {
         get {

--- a/AzureData/AzureData.xcodeproj/project.pbxproj
+++ b/AzureData/AzureData.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		321CD7CE227599CF0036E8B1 /* DocumentProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321CD7CD227599CF0036E8B1 /* DocumentProperties.swift */; };
+		321CD7CF227599CF0036E8B1 /* DocumentProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321CD7CD227599CF0036E8B1 /* DocumentProperties.swift */; };
+		321CD7D0227599CF0036E8B1 /* DocumentProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321CD7CD227599CF0036E8B1 /* DocumentProperties.swift */; };
+		321CD7D1227599CF0036E8B1 /* DocumentProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321CD7CD227599CF0036E8B1 /* DocumentProperties.swift */; };
 		3234ABF3223D40C400270767 /* PartitionKeyRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3234ABF2223D40C400270767 /* PartitionKeyRange.swift */; };
 		3234ABF4223D40C400270767 /* PartitionKeyRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3234ABF2223D40C400270767 /* PartitionKeyRange.swift */; };
 		3234ABF5223D40C400270767 /* PartitionKeyRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3234ABF2223D40C400270767 /* PartitionKeyRange.swift */; };
@@ -381,6 +385,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		321CD7CD227599CF0036E8B1 /* DocumentProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentProperties.swift; sourceTree = "<group>"; };
 		3234ABF2223D40C400270767 /* PartitionKeyRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartitionKeyRange.swift; sourceTree = "<group>"; };
 		3234ABF8223EB35A00270767 /* Point.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Point.swift; sourceTree = "<group>"; };
 		3234AC03223EBD6500270767 /* PointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointTests.swift; sourceTree = "<group>"; };
@@ -752,6 +757,7 @@
 				B58361BD1FBA13A0001CEC66 /* Document.swift */,
 				3295124522146B8D00E8A069 /* DocumentContainer.swift */,
 				B58361C21FBA13B0001CEC66 /* DocumentCollection.swift */,
+				321CD7CD227599CF0036E8B1 /* DocumentProperties.swift */,
 				3295125F2214A82600E8A069 /* Documents.swift */,
 				B58361D11FBA15A8001CEC66 /* Offer.swift */,
 				3234ABF2223D40C400270767 /* PartitionKeyRange.swift */,
@@ -1118,6 +1124,7 @@
 				931EA5C41FBE6920003CCFF4 /* DocumentClientExtensions.swift in Sources */,
 				32DA0942224FF5FA0065FF83 /* LineString.swift in Sources */,
 				B58361B41FB78F7A001CEC66 /* ResponseExtensions.swift in Sources */,
+				321CD7CF227599CF0036E8B1 /* DocumentProperties.swift in Sources */,
 				B52241021FB3409F00D0343F /* AzureData.swift in Sources */,
 				B52240B21FB3409000D0343F /* ResourceType.swift in Sources */,
 				32DA093D224F99B60065FF83 /* CLLocationCoordinate2D+Equatable.swift in Sources */,
@@ -1225,6 +1232,7 @@
 				931EA5C61FBE6922003CCFF4 /* DocumentClientExtensions.swift in Sources */,
 				32DA0943224FF5FA0065FF83 /* LineString.swift in Sources */,
 				B58361AF1FB78F7A001CEC66 /* ResponseExtensions.swift in Sources */,
+				321CD7D0227599CF0036E8B1 /* DocumentProperties.swift in Sources */,
 				B52240FD1FB3409E00D0343F /* AzureData.swift in Sources */,
 				B52240C71FB3409100D0343F /* ResourceType.swift in Sources */,
 				32DA093E224F99B60065FF83 /* CLLocationCoordinate2D+Equatable.swift in Sources */,
@@ -1332,6 +1340,7 @@
 				931EA5C51FBE6922003CCFF4 /* DocumentClientExtensions.swift in Sources */,
 				32DA0944224FF5FA0065FF83 /* LineString.swift in Sources */,
 				B58361AA1FB78F78001CEC66 /* ResponseExtensions.swift in Sources */,
+				321CD7D1227599CF0036E8B1 /* DocumentProperties.swift in Sources */,
 				B52240F81FB3409D00D0343F /* AzureData.swift in Sources */,
 				B52240DC1FB3409200D0343F /* ResourceType.swift in Sources */,
 				32DA093F224F99B60065FF83 /* CLLocationCoordinate2D+Equatable.swift in Sources */,
@@ -1404,6 +1413,7 @@
 				B583619D1FB77A70001CEC66 /* Resources.swift in Sources */,
 				B52241071FB3409F00D0343F /* AzureData.swift in Sources */,
 				B58361F01FBA19A7001CEC66 /* DatabaseAccount.swift in Sources */,
+				321CD7CE227599CF0036E8B1 /* DocumentProperties.swift in Sources */,
 				9319DEF320698F260083475D /* PermissionProviderError.swift in Sources */,
 				B522409D1FB3408E00D0343F /* ResourceType.swift in Sources */,
 				323AE94A2080230E00EAE1F5 /* SupportsPermissionToken.swift in Sources */,

--- a/AzureData/README.md
+++ b/AzureData/README.md
@@ -472,6 +472,42 @@ collection.query (documentsAcrossAllPartitionsWith: query, as: Person.self) { r 
 }
 ```
 
+##### Query a subset of properties
+It's possible to query only a subset of a document properties to reduce responses payload or to reduce the costs of usage.
+
+```swift
+let query = Query.select("firstName", "lastName")
+                .from("Person")
+                .orderBy("birthCity")
+
+AzureData.query (documentPropertiesIn: collectionId, inDatabase: databaseId, with: query, andPartitionKey: partitionKey) { r in
+    // properties = r.resource?.items
+}
+
+AzureData.query (documentPropertiesAcrossAllPartitionsIn: collectionId, inDatabase: databaseId, with: query) { r in 
+    // properties = r.resource?.items
+}
+
+collection.query (documentPropertiesWith: query, andPartitionKey: partitionKey) { r in 
+    // properties = r.resource?.items
+}
+```
+
+Each of the resources returned by the above functions is of the type `DocumentProperties`. `DocumentProperties` should be used like a standard Swift dictionary. The values of the queried properties can be retrieved using the subscript operator. Properties not specified in the `select` fragment of the query will have `nil` values if tried to be retrieved with the subscript operator.
+
+```swift
+let query = Query.select("birthCity")
+                .from("Person")
+                .where("firstName", is: "Faiçal")
+                .and("lastName" is: "Tchirou")
+
+AzureData.query (documentPropertiesAcrossAllPartitionsIn: collectionId, inDatabase: databaseId, with: query) { r in 
+    let properties = r.resource?.items.first
+    let birthCity = properties["birthCity"] // -> Returns the value of the `birthCity` property.
+    let firstName = properties["firstName"] // -> Returns `nil` because the property `firstName` was not specified in the query.
+    let lastName = properties["lastName"] // -> Returns `nil` because the property `lastName` was not specified in the query.
+}
+```
 ## Attachments
 
 #### Create

--- a/AzureData/Source/AzureData.swift
+++ b/AzureData/Source/AzureData.swift
@@ -271,6 +271,22 @@ public class AzureData {
         return DocumentClient.shared.query (documentsIn: collection, as: documentType, with: query, andPartitionKey: nil, maxPerPage: maxPerPage, callback: callback)
     }
 
+    public static func query (documentPropertiesIn collectionId: String, inDatabase databaseId: String, with query: Query, andPartitionKey partitionKey: String, maxPerPage: Int? = nil, callback: @escaping (Response<Documents<DocumentProperties>>) -> ()) {
+        return DocumentClient.shared.query (documentsIn: collectionId, as: DocumentProperties.self, inDatabase: databaseId, with: query, andPartitionKey: partitionKey, maxPerPage: maxPerPage, callback: callback)
+    }
+
+    public static func query (documentPropertiesIn collection: DocumentCollection, with query: Query, andPartitionKey partitionKey: String, maxPerPage: Int? = nil, callback: @escaping (Response<Documents<DocumentProperties>>) -> ()) {
+        return DocumentClient.shared.query (documentsIn: collection, as: DocumentProperties.self, with: query, andPartitionKey: partitionKey, maxPerPage: maxPerPage, callback: callback)
+    }
+
+    public static func query (documentPropertiesAcrossAllPartitionsIn collectionId: String, inDatabase databaseId: String, with query: Query, maxPerPage: Int? = nil, callback: @escaping (Response<Documents<DocumentProperties>>) -> ()) {
+        return DocumentClient.shared.query (documentsIn: collectionId, as: DocumentProperties.self, inDatabase: databaseId, with: query, andPartitionKey: nil, maxPerPage: maxPerPage, callback: callback)
+    }
+
+    public static func query (documentPropertiesAcrossAllPartitionsIn collection: DocumentCollection, with query: Query, maxPerPage: Int? = nil, callback: @escaping (Response<Documents<DocumentProperties>>) -> ()) {
+        return DocumentClient.shared.query (documentsIn: collection, as: DocumentProperties.self, with: query, andPartitionKey: nil, maxPerPage: maxPerPage, callback: callback)
+    }
+
     // delete
     public static func delete<T: Document>(_ document: T, callback: @escaping (Response<Data>) -> ()) {
         return DocumentClient.shared.delete(document, callback: callback)

--- a/AzureData/Source/AzureDataExtensions.swift
+++ b/AzureData/Source/AzureDataExtensions.swift
@@ -11,7 +11,7 @@ import AzureCore
 
 // MARK: -
 
-public extension CodableResource {
+extension CodableResource {
     
     public func delete(_ callback: @escaping (Response<Data>) -> ()) {
         return DocumentClient.shared.delete(self, callback: callback)
@@ -22,7 +22,7 @@ public extension CodableResource {
     }
 }
 
-public extension CodableResource where Self: SupportsPermissionToken {
+extension CodableResource where Self: SupportsPermissionToken {
 
     public func create(permissionWithId permissionId: String, mode permissionMode: PermissionMode, for user: User, callback: @escaping (Response<Permission>) -> ()) {
         return DocumentClient.shared.create(permissionWithId: permissionId, mode: permissionMode, in: self, for: user, callback: callback)
@@ -32,7 +32,7 @@ public extension CodableResource where Self: SupportsPermissionToken {
 
 // MARK: -
 
-public extension Database {
+extension Database {
 
     // MARK: Document Collection
     
@@ -97,7 +97,7 @@ public extension Database {
 
 // MARK: -
 
-public extension DocumentCollection {
+extension DocumentCollection {
     
     // MARK: Documents
     
@@ -146,7 +146,15 @@ public extension DocumentCollection {
     public func query<T: Document> (documentsAcrossAllPartitionsWith query: Query, as documentType: T.Type, maxPerPage: Int? = nil, callback: @escaping (Response<Documents<T>>) -> ()) {
         return DocumentClient.shared.query(documentsIn: self, as: documentType, with: query, andPartitionKey: nil, maxPerPage: maxPerPage, callback: callback)
     }
-    
+
+    public func query (documentPropertiesWith query: Query, andPartitionKey partitionKey: String, maxPerPage: Int? = nil, callback: @escaping (Response<Documents<DocumentProperties>>) -> ()) {
+        return DocumentClient.shared.query (documentsIn: self, as: DocumentProperties.self, with: query, andPartitionKey: partitionKey, maxPerPage: maxPerPage, callback: callback)
+    }
+
+    public func query (documentPropertiesAcrossAllPartitionsWith query: Query, maxPerPage: Int? = nil, callback: @escaping (Response<Documents<DocumentProperties>>) -> ()) {
+        return DocumentClient.shared.query (documentsIn: self, as: DocumentProperties.self, with: query, andPartitionKey: nil, maxPerPage: maxPerPage, callback: callback)
+    }
+
     // MARK: Stored Procedures
     
     // create
@@ -243,7 +251,7 @@ public extension DocumentCollection {
 
 // MARK: -
 
-public extension Document {
+extension Document {
     
     // MARK: Attachments
     
@@ -284,7 +292,7 @@ public extension Document {
 
 // MARK: -
 
-public extension User {
+extension User {
     
     // MARK: Permissions
     
@@ -320,7 +328,7 @@ public extension User {
 
 // MARK: -
 
-public extension StoredProcedure {
+extension StoredProcedure {
 
     // execute
     public func execute (usingParameters parameters: [String]?, callback: @escaping (Response<Data>) -> ()) {

--- a/AzureData/Source/DocumentClient.swift
+++ b/AzureData/Source/DocumentClient.swift
@@ -330,7 +330,14 @@ class DocumentClient {
         }
     }
 
-    
+    func query(documentPropertiesIn collectionId: String, inDatabase databaseId: String, with query: Query, andPartitionKey partitionKey: String?, maxPerPage: Int? = nil, callback: @escaping (Response<Documents<DocumentProperties>>) -> ()) {
+        return self.query(documentsIn: collectionId, as: DocumentProperties.self, inDatabase: databaseId, with: query, andPartitionKey: partitionKey, maxPerPage: maxPerPage, callback: callback)
+    }
+
+    func query(documentPropertiesIn collection: DocumentCollection, with query: Query, andPartitionKey partitionKey: String?, maxPerPage: Int? = nil, callback: @escaping (Response<Documents<DocumentProperties>>) -> ()) {
+        return self.query(documentsIn: collection, as: DocumentProperties.self, with: query, andPartitionKey: partitionKey, maxPerPage: maxPerPage, callback: callback)
+    }
+
     // MARK: - Attachments
     
     // create

--- a/AzureData/Source/DocumentClientError.swift
+++ b/AzureData/Source/DocumentClientError.swift
@@ -165,7 +165,7 @@ extension HttpStatusCode {
 }
 
 
-public extension Optional where Wrapped == DocumentClientError {
+extension Optional where Wrapped == DocumentClientError {
     public var isConnectivityError: Bool {
         return self?.baseError?.isConnectivityError ?? false
     }
@@ -183,13 +183,13 @@ extension DocumentClientError : CustomDebugStringConvertible {
     }
 }
 
-public extension DocumentClientError {
+extension DocumentClientError {
     public var localizedDescription: String {
         return self.message
     }
 }
 
-public extension Response {
+extension Response {
     
     public var clientError: DocumentClientError? {
         return error as? DocumentClientError

--- a/AzureData/Source/MSHttpHeader.swift
+++ b/AzureData/Source/MSHttpHeader.swift
@@ -54,7 +54,7 @@ public enum MSHttpHeader : String {
 }
 
 
-public extension Dictionary where Key == String, Value == Any {
+extension Dictionary where Key == String, Value == Any {
     public subscript (index: MSHttpHeader) -> Any? {
         get {
             return self[index.rawValue]
@@ -65,7 +65,7 @@ public extension Dictionary where Key == String, Value == Any {
     }
 }
 
-public extension Dictionary where Key == String, Value == String {
+extension Dictionary where Key == String, Value == String {
     public subscript (index: MSHttpHeader) -> String? {
         get {
             return self[index.rawValue]

--- a/AzureData/Source/Query.swift
+++ b/AzureData/Source/Query.swift
@@ -39,7 +39,7 @@ public class Query : Encodable {
         try container.encode(parameters.isEmpty ? [] : [parameters], forKey: .parameters)
     }
     
-    init(_ properties: [String]? = nil) {
+    internal init(_ properties: [String]? = nil) {
         selectCalled = true
         
         if let properties = properties, !properties.isEmpty {
@@ -48,19 +48,18 @@ public class Query : Encodable {
     }
     
     public static func select() -> Query {
-        //assert(!selectCalled, "you can only call select once")
-        //selectCalled = true;
-        
-        return Query()
+        let query = Query()
+        query.selectCalled = true
+
+        return query
     }
     
     public static func select(_ properties: String...) -> Query {
-        //        assert(selectCalled, "you can only call `select` once")
-        //        selectCalled = true;
-        
-        //        self.selectProperties = properties
-        
-        return Query()
+        let query = Query()
+        query.selectCalled = true
+        query.selectProperties = properties
+
+        return query
     }
     
     

--- a/AzureData/Source/ResourceWriteOperation.swift
+++ b/AzureData/Source/ResourceWriteOperation.swift
@@ -59,8 +59,8 @@ extension ResourceWriteOperation: Equatable {
 // MARK: - Hashable
 
 extension ResourceWriteOperation: Hashable {
-    var hashValue: Int {
-        return resourceLocalContentPath.hashValue
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(resourceLocalContentPath.hashValue)
     }
 }
 

--- a/AzureData/Source/Resources/DocumentContainer.swift
+++ b/AzureData/Source/Resources/DocumentContainer.swift
@@ -12,27 +12,27 @@ final class DocumentContainer<DocumentType: Document>: CodableResource, Supports
     static var type: String { return "docs" }
     static var list: String { return "Documents" }
 
-    var id: String { return metadata.id }
-    var resourceId: String { return metadata.id }
-    var selfLink: String? { return metadata.selfLink }
-    var etag: String? { return metadata.etag }
-    var timestamp: Date? { return metadata.timestamp }
-    var altLink: String? { return metadata.altLink }
-    var attachmentsLink: String? { return metadata.attachmentsLink }
+    var id: String { return document.id }
+    var resourceId: String { return metadata?.resourceId ?? "" }
+    var selfLink: String? { return metadata?.selfLink }
+    var etag: String? { return metadata?.etag }
+    var timestamp: Date? { return metadata?.timestamp }
+    var altLink: String? { return metadata?.altLink }
+    var attachmentsLink: String? { return metadata?.attachmentsLink }
 
-    var metadata: DocumentMetadata
+    var metadata: DocumentMetadata?
     var document: DocumentType
 
     func setAltLink(to link: String) {
-        metadata.altLink = link
+        metadata?.altLink = link
     }
 
     func setEtag(to tag: String) {
-        metadata.etag = tag
+        metadata?.etag = tag
     }
 
     internal init(_ document: DocumentType) {
-        self.metadata = DocumentMetadata(id: document.id, resourceId: "")
+        self.metadata = DocumentMetadata(resourceId: "")
         self.document = document
     }
 
@@ -41,20 +41,21 @@ final class DocumentContainer<DocumentType: Document>: CodableResource, Supports
     }
 
     required init(from decoder: Decoder) throws {
-        self.metadata = try DocumentMetadata(from: decoder)
+        self.metadata = try? DocumentMetadata(from: decoder)
         self.document = try DocumentType(from: decoder)
-        self.document.metadata = self.metadata
+        if let metadata = self.metadata {
+            self.document.metadata = metadata
+        }
     }
 
     func encode(to encoder: Encoder) throws {
-        try metadata.encode(to: encoder)
+        try metadata?.encode(to: encoder)
         try document.encode(to: encoder)
     }
 }
 
 final class DocumentMetadata: Codable {
     enum CodingKeys: String, CodingKey {
-        case id
         case resourceId         = "_rid"
         case selfLink           = "_self"
         case etag               = "_etag"
@@ -62,7 +63,6 @@ final class DocumentMetadata: Codable {
         case attachmentsLink    = "_attachments"
     }
 
-    let id: String
     let resourceId: String
     let selfLink:   String?
     var etag:       String?
@@ -78,8 +78,7 @@ final class DocumentMetadata: Codable {
         etag = tag
     }
 
-    init(id: String, resourceId: String, selfLink: String? = nil, etag: String? = nil, timestamp: Date? = nil, altLink: String? = nil, attachmentsLink: String? = nil) {
-        self.id = id
+    init(resourceId: String, selfLink: String? = nil, etag: String? = nil, timestamp: Date? = nil, altLink: String? = nil, attachmentsLink: String? = nil) {
         self.resourceId = resourceId
         self.selfLink = selfLink
         self.etag = etag

--- a/AzureData/Source/Resources/DocumentProperties.swift
+++ b/AzureData/Source/Resources/DocumentProperties.swift
@@ -1,0 +1,36 @@
+//
+//  DocumentDictionary.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+public final class DocumentProperties: Document {
+    public static let partitionKey: PartitionKey? = nil
+
+    private let contents: CodableDictionary
+    private lazy var dictionary: [String: Any] = contents.dictionary.compactMapValues { $0 }
+
+    public var id: String {
+        return contents["id"] as? String ?? ""
+    }
+
+    internal init(id: String) {
+        self.contents = [:]
+    }
+
+    subscript(index: String) -> Any? {
+        return dictionary[index]
+    }
+
+    public init(from decoder: Decoder) throws {
+        self.contents = try CodableDictionary(from: decoder)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        try self.contents.encode(to: encoder)
+    }
+}

--- a/AzureMobile/AzureMobile.xcodeproj/project.pbxproj
+++ b/AzureMobile/AzureMobile.xcodeproj/project.pbxproj
@@ -394,6 +394,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 9345CF7020CB003C0002247E;
 			productRefGroup = 9345CF7B20CB003C0002247E /* Products */;

--- a/AzurePush/AzurePush.xcodeproj/project.pbxproj
+++ b/AzurePush/AzurePush.xcodeproj/project.pbxproj
@@ -441,6 +441,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 93F8051A202BB06900D0B4F4;
 			productRefGroup = 93F80525202BB06900D0B4F4 /* Products */;

--- a/AzureStorage/AzureStorage.xcodeproj/project.pbxproj
+++ b/AzureStorage/AzureStorage.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 939E836F202CC5D80020574D;
 			productRefGroup = 939E837A202CC5D80020574D /* Products */;


### PR DESCRIPTION
Thanks for taking the time to contribute. Please take a moment to fill out the information below.

Fixes #122.

Changes Proposed in this pull request:
- Fix some warnings
- Improve the `DocumentMetadata` model by removing the `id` field (which belong in the `Document` protocol)
- Add support for querying a subset of documents properties (see the [updated documentation](https://github.com/Azure/Azure.iOS/compare/feature/partial-queries?expand=1#diff-7f894c0373c91b36a8a4e11680fafd14R475) for the usage of the new API functions).
- Update the documentation