### PR TITLE
Add support for partition keys when executing stored procedures

### DIFF
--- a/AzureData/AzureData.xcodeproj/project.pbxproj
+++ b/AzureData/AzureData.xcodeproj/project.pbxproj
@@ -69,6 +69,9 @@
 		32799700209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327996FE209C830C0062A374 /* ResourceWriteOperationQueue.swift */; };
 		32799701209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327996FE209C830C0062A374 /* ResourceWriteOperationQueue.swift */; };
 		32799702209C830C0062A374 /* ResourceWriteOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327996FE209C830C0062A374 /* ResourceWriteOperationQueue.swift */; };
+		328D005222651EF4003120A8 /* _StoredProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328D005122651EF4003120A8 /* _StoredProcedureTests.swift */; };
+		328D005322651EF4003120A8 /* _StoredProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328D005122651EF4003120A8 /* _StoredProcedureTests.swift */; };
+		328D005422651EF4003120A8 /* _StoredProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328D005122651EF4003120A8 /* _StoredProcedureTests.swift */; };
 		3295124622146B8D00E8A069 /* DocumentContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3295124522146B8D00E8A069 /* DocumentContainer.swift */; };
 		3295124722146B8D00E8A069 /* DocumentContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3295124522146B8D00E8A069 /* DocumentContainer.swift */; };
 		3295124822146B8D00E8A069 /* DocumentContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3295124522146B8D00E8A069 /* DocumentContainer.swift */; };
@@ -400,6 +403,7 @@
 		324301F72213779C009D209F /* PartitionKeyDefinition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PartitionKeyDefinition.swift; sourceTree = "<group>"; };
 		32532A59207825A1002BFFCA /* ResponseMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseMetadata.swift; sourceTree = "<group>"; };
 		327996FE209C830C0062A374 /* ResourceWriteOperationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceWriteOperationQueue.swift; sourceTree = "<group>"; };
+		328D005122651EF4003120A8 /* _StoredProcedureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _StoredProcedureTests.swift; sourceTree = "<group>"; };
 		3295124522146B8D00E8A069 /* DocumentContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentContainer.swift; sourceTree = "<group>"; };
 		3295125F2214A82600E8A069 /* Documents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Documents.swift; sourceTree = "<group>"; };
 		329512C622157C5B00E8A069 /* TestDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDocument.swift; sourceTree = "<group>"; };
@@ -706,6 +710,7 @@
 				B52240461FB33D1200D0343F /* UserTests.swift */,
 				9317A81B2065763700338B63 /* ResourceOracleTests.swift */,
 				323A90F120800DEB00537769 /* Extensions.swift */,
+				328D005122651EF4003120A8 /* _StoredProcedureTests.swift */,
 			);
 			name = ResourceTests;
 			sourceTree = "<group>";
@@ -1170,6 +1175,7 @@
 				B52240761FB33DF800D0343F /* CollectionDocumentExtensionsTests.swift in Sources */,
 				32AABD1F20AC9FB900F66DC6 /* OfflineWriteTests.swift in Sources */,
 				3236507322500C8300D329B1 /* PolygonTests.swift in Sources */,
+				328D005322651EF4003120A8 /* _StoredProcedureTests.swift in Sources */,
 				3236506A225007EB00D329B1 /* LineStringTests.swift in Sources */,
 				B522406F1FB33DF800D0343F /* AttachmentTests.swift in Sources */,
 				932832E72072CD9E0075ECC7 /* ExamplePermissionProviderTests.swift in Sources */,
@@ -1277,6 +1283,7 @@
 				B522408A1FB33DFA00D0343F /* CollectionDocumentExtensionsTests.swift in Sources */,
 				32AABD2020AC9FB900F66DC6 /* OfflineWriteTests.swift in Sources */,
 				3236507422500C8300D329B1 /* PolygonTests.swift in Sources */,
+				328D005422651EF4003120A8 /* _StoredProcedureTests.swift in Sources */,
 				3236506B225007EB00D329B1 /* LineStringTests.swift in Sources */,
 				B52240831FB33DFA00D0343F /* AttachmentTests.swift in Sources */,
 				932832E82072CD9E0075ECC7 /* ExamplePermissionProviderTests.swift in Sources */,
@@ -1448,6 +1455,7 @@
 				B52240621FB33DF100D0343F /* CollectionDocumentExtensionsTests.swift in Sources */,
 				32AABD1E20AC9FB900F66DC6 /* OfflineWriteTests.swift in Sources */,
 				3236507222500C8300D329B1 /* PolygonTests.swift in Sources */,
+				328D005222651EF4003120A8 /* _StoredProcedureTests.swift in Sources */,
 				32365069225007EB00D329B1 /* LineStringTests.swift in Sources */,
 				B522405B1FB33DF100D0343F /* AttachmentTests.swift in Sources */,
 				932832E62072CD9E0075ECC7 /* ExamplePermissionProviderTests.swift in Sources */,

--- a/AzureData/Source/AzureData.swift
+++ b/AzureData/Source/AzureData.swift
@@ -384,7 +384,13 @@ public class AzureData {
         return DocumentClient.shared.execute (storedProcedureWithId: storedProcedureId, usingParameters: parameters, in: collection, callback: callback)
     }
 
+    public static func execute (storedProcedureWithId storedProcedureId: String, usingParameters parameters: [String]?, andPartitionKey partitionKey: String, inCollection collectionId: String, inDatabase databaseId: String, callback: @escaping (Response<Data>) -> ()) {
+        return DocumentClient.shared.execute (storedProcedureWithId: storedProcedureId, usingParameters: parameters, andPartitionKey: partitionKey, inCollection: collectionId, inDatabase: databaseId, callback: callback)
+    }
 
+    public static func execute (storedProcedureWithId storedProcedureId: String, usingParameters parameters: [String]?, andPartitionKey partitionKey: String, in collection: DocumentCollection, callback: @escaping (Response<Data>) -> ()) {
+        return DocumentClient.shared.execute (storedProcedureWithId: storedProcedureId, usingParameters: parameters, andPartitionKey: partitionKey, in: collection, callback: callback)
+    }
 
 
     // MARK: - User Defined Functions

--- a/AzureData/Source/AzureDataExtensions.swift
+++ b/AzureData/Source/AzureDataExtensions.swift
@@ -181,7 +181,10 @@ public extension DocumentCollection {
     public func execute (storedProcedureWithId id: String, usingParameters parameters: [String]?, callback: @escaping (Response<Data>) -> ()) {
         return DocumentClient.shared.execute (storedProcedureWithId: id, usingParameters: parameters, in: self, callback: callback)
     }
-    
+
+    public func execute (storedProcedureWithId id: String, usingParameters parameters: [String]?, andPartitionKey partitionKey: String, callback: @escaping (Response<Data>) -> ()) {
+        return DocumentClient.shared.execute (storedProcedureWithId: id, usingParameters: parameters, andPartitionKey: partitionKey, in: self, callback: callback)
+    }
     
     
     // MARK: User Defined Functions

--- a/AzureData/Source/DocumentClient.swift
+++ b/AzureData/Source/DocumentClient.swift
@@ -457,9 +457,15 @@ class DocumentClient {
         return self.execute(StoredProcedure.self, withBody: parameters, at: .child(.storedProcedure, in: collection, id: storedProcedureId), callback: callback)
     }
 
+    func execute (storedProcedureWithId storedProcedureId: String, usingParameters parameters: [String]?, andPartitionKey partitionKey: String, inCollection collectionId: String, inDatabase databaseId: String, callback: @escaping (Response<Data>) -> ()) {
+        let headers = HttpHeaders.msDocumentdbPartitionKey(partitionKey)
+        return self.execute(StoredProcedure.self, withBody: parameters, at: .storedProcedure(databaseId: databaseId, collectionId: collectionId, id: storedProcedureId), additionalHeaders: headers, callback: callback)
+    }
     
-    
-
+    func execute (storedProcedureWithId storedProcedureId: String, usingParameters parameters: [String]?, andPartitionKey partitionKey: String, in collection: DocumentCollection, callback: @escaping (Response<Data>) -> ()) {
+        let headers = HttpHeaders.msDocumentdbPartitionKey(partitionKey)
+        return self.execute(StoredProcedure.self, withBody: parameters, at: .child(.storedProcedure, in: collection, id: storedProcedureId), additionalHeaders: headers, callback: callback)
+    }
     
     // MARK: - User Defined Functions
     
@@ -976,11 +982,11 @@ class DocumentClient {
     }
 
     // execute
-    fileprivate func execute<T:CodableResource, R: Encodable>(_ type: T.Type, withBody body: R? = nil, at resourceLocation: ResourceLocation, callback: @escaping (Response<Data>) -> ()) {
+    fileprivate func execute<T:CodableResource, R: Encodable>(_ type: T.Type, withBody body: R? = nil, at resourceLocation: ResourceLocation, additionalHeaders: HttpHeaders = [:], callback: @escaping (Response<Data>) -> ()) {
         
         guard !isOffline else { callback(Response(DocumentClientError(withKind: .serviceUnavailable))); return }
-        
-        dataRequest(forResourceAt: resourceLocation, withMethod: .post) { r in
+
+        dataRequest(forResourceAt: resourceLocation, withMethod: .post, andAdditionalHeaders: additionalHeaders) { r in
             
             if var request = r.resource {
                 

--- a/AzureData/Source/Resources/Document.swift
+++ b/AzureData/Source/Resources/Document.swift
@@ -14,7 +14,7 @@ import Foundation
 ///   A document is a structured JSON document. There is no set schema for the JSON documents,
 ///   and a document may contain any number of custom properties as well as an optional list of attachments.
 ///   Document is an application resource and can be authorized using the master key or resource keys.
-public protocol Document: class, Codable {
+public protocol Document: AnyObject, Codable {
     typealias PartitionKey = KeyPath<Self, String>
 
     /// Gets the partition key used to automatically partition data

--- a/AzureData/Tests/_AzureDataTests.swift
+++ b/AzureData/Tests/_AzureDataTests.swift
@@ -21,12 +21,13 @@ class _AzureDataTests: XCTestCase {
 
     var rname: String { return resourceName ?? resourceType.path.capitalized }
 
-    var databaseId:     String { return "\(rname)TestsDatabase" }
-    var collectionId:   String { return "\(rname)TestsCollection" }
-    var documentId:     String { return "\(rname)TestsDocument" }
-    var userId:         String { return "\(rname)TestsUser" }
-    var resourceId:     String { return "\(rname)Tests\(rname)" }
-    var replacedId:     String { return "\(rname)Replaced" }
+    var databaseId:        String { return "\(rname)TestsDatabase" }
+    var collectionId:      String { return "\(rname)TestsCollection" }
+    var documentId:        String { return "\(rname)TestsDocument" }
+    var userId:            String { return "\(rname)TestsUser" }
+    var resourceId:        String { return "\(rname)Tests\(rname)" }
+    var replacedId:        String { return "\(rname)Replaced" }
+    var storedProcedureId: String { return "\(rname)TestsStoredProcedure" }
 
     lazy var createExpectation   = self.expectation(description: "should create and return \(rname)")
     lazy var listExpectation     = self.expectation(description: "should return a list of \(rname)")

--- a/AzureData/Tests/_StoredProcedureTests.swift
+++ b/AzureData/Tests/_StoredProcedureTests.swift
@@ -1,0 +1,71 @@
+//
+//  _StoredProcedureTests.swift
+//  AzureData
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import XCTest
+@testable import AzureData
+@testable import AzureCore
+
+class _StoredProcedureTests: _AzureDataTests {
+    override func setUp() {
+        resourceType = .storedProcedure
+        resourceName = "StoredProcedure"
+        partitionKey = "/birthCity"
+        super.setUp()
+        super.tearDown()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testStoredProcedureWithQuery() {
+        let expectation = self.expectation(description: "should execute stored procedure with a query")
+
+        let document1 = TestDocument.stub(documentId + "1")
+        let document2 = TestDocument.stub(documentId + "2")
+        let document3 = TestDocument.stub(documentId + "3")
+
+        ensureDocumentExists(document1)
+        ensureDocumentExists(document2)
+        ensureDocumentExists(document3)
+
+        let body =
+            """
+                function (arg) {
+                    var collection = getContext().getCollection();
+                    var isAccepted = collection.queryDocuments(
+                        collection.getSelfLink(),
+                        `SELECT * FROM collectionId`,
+                        function (err, feed, options) {
+                            if (err) throw err;
+                            if (!feed || !feed.length) {
+                                var response = getContext().getResponse();
+                                var body = { feed: feed };
+                                response.setBody(JSON.stringify(body));
+                            }
+                        }
+                    );
+
+                    if (!isAccepted) throw new Error('The query was not accepted by the server.');
+                }
+            """
+
+        AzureData.create(storedProcedureWithId: storedProcedureId, andBody: body, inCollection: collectionId, inDatabase: databaseId) { r in
+            XCTAssertTrue(r.result.isSuccess)
+
+            let partitionKey = document1[keyPath: TestDocument.partitionKey!]
+            AzureData.execute(storedProcedureWithId: self.storedProcedureId, usingParameters: nil, andPartitionKey: partitionKey, inCollection: self.collectionId, inDatabase: self.databaseId) { r in
+                XCTAssertTrue(r.result.isSuccess)
+
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: timeout)
+    }
+}


### PR DESCRIPTION
Fixes #121.

Changes Proposed in this pull request:
- Adds overloads of `execute(storedProcedure...)` with a new parameter for the partition key
- Updates the tests
