### PR TITLE
fix issue #127 : Replace AzureCore.Result with Swift.Result

### DIFF
--- a/AzureData/Source/DocumentClient.swift
+++ b/AzureData/Source/DocumentClient.swift
@@ -831,7 +831,7 @@ class DocumentClient {
 
                     callback(response)
                     
-                    if response.result.isSuccess {
+                    if case .success = response.result {
                         ResourceCache.remove(resourceAt: resourceLocation)
                     }
                 }

--- a/AzureData/Source/ResourceWriteOperationQueue.swift
+++ b/AzureData/Source/ResourceWriteOperationQueue.swift
@@ -38,7 +38,7 @@ class ResourceWriteOperationQueue {
         createOrReplaceOffline(resource: resource, at: location, replacing: replacing) { [weak self] r in
             callback(r)
 
-            if r.result.isSuccess {
+            if case .success = r.result {
                 let type: ResourceWriteOperation.Kind = replacing ? .replace : .create
                 self?.enqueue(ResourceWriteOperation(type: type, resource: resource, resourceLocation: location, resourceLocalContentPath: r.msContentPath!, httpHeaders: httpHeaders))
             }
@@ -51,7 +51,7 @@ class ResourceWriteOperationQueue {
         deleteOffline(resourceAt: location) { [weak self] r in
             callback(r)
 
-            if r.result.isSuccess {
+            if case .success = r.result {
                 self?.enqueue(ResourceWriteOperation(type: .delete, resource: nil, resourceLocation: location, resourceLocalContentPath: r.msContentPath!, httpHeaders: httpHeaders))
             }
         }

--- a/AzureData/Source/ResponseExtensions.swift
+++ b/AzureData/Source/ResponseExtensions.swift
@@ -113,12 +113,11 @@ extension Response where T: OptionalType {
             request: request,
             data: data,
             response: response,
-            result: result.map { data in
-                if data.optional == nil {
-                    throw error()
-                }
-                return data.optional!
-            },
+            result: {
+                guard case let .success(resource) = result, resource.optional != nil
+                    else { return .failure(error()) }
+                return .success(resource.optional!)
+            }(),
             fromCache: fromCache
         )
     }


### PR DESCRIPTION
Fixes #127 

We created `AzureCore.Result` before a `Result` type was added to Swift.  Fortunately our type was similar enough to Swift's implementation that minimal changes were required to update to use `Swift.Result` and remove `AzureCore.Result` altogether.